### PR TITLE
Fix: CMS-40996-support-pushing-content

### DIFF
--- a/packages/optimizely-cms-cli/src/service/utils.ts
+++ b/packages/optimizely-cms-cli/src/service/utils.ts
@@ -42,7 +42,7 @@ export async function findContentTypes(
         const contentType = isContentType(obj)
           ? obj
           : isContentType(obj?.ContentType)
-          ? obj
+          ? obj?.ContentType
           : null;
 
         if (contentType) {

--- a/samples/nextjs-template/src/components/Article.tsx
+++ b/samples/nextjs-template/src/components/Article.tsx
@@ -5,5 +5,3 @@ export const ContentType = contentType({
   displayName: 'Landing page',
   baseType: 'experience',
 });
-
-export default function X() {}


### PR DESCRIPTION
This fix the issue of having additional `contentTypes` field on the config

```
{
  "contentTypes": [
    {
      "ContentType": {
        "key": "Contact",
        "displayName": "Contact Us page",
        "baseType": "page"
      }
    },
    {
      "ContentType": {
        "key": "Landing",
        "displayName": "Landing page",
        "baseType": "experience"
      }
    }
  ]
}
```


To this 


```
{
  "contentTypes": [
    {
      "key": "Contact",
      "displayName": "Contact Us page",
      "baseType": "page"
    },
    {
      "key": "Landing",
      "displayName": "Landing page",
      "baseType": "experience"
    }
  ]
}

```