### PR TITLE
Map model properties to the manifest

### DIFF
--- a/packages/optimizely-cms-cli/src/commands/config/push.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/push.ts
@@ -5,7 +5,8 @@ import { BaseCommand } from '../../baseCommand.js';
 import { writeFile } from 'node:fs/promises';
 import chalk from 'chalk';
 import { createApiClient } from '../../service/cmsRestClient.js';
-import { Config, findContentTypes } from '../../service/utils.js';
+import { findContentTypes } from '../../service/utils.js';
+import { mapContentToManifest } from '../../mapper/contentToPackage.js';
 
 export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
   static override args = {
@@ -27,7 +28,7 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
 
     const jsConfig = await import(configPath).then(
       // Assume that the default import _is_ a jsConfig
-      (m) => m.default as Config
+      (m) => m.default
     );
 
     if (typeof jsConfig.contentTypes === 'string') {
@@ -46,9 +47,11 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
         );
       }
 
-      jsConfig.contentTypes = contentTypes.map(
+      const extractedContentTypes = contentTypes.map(
         ({ contentType }) => contentType
       );
+
+      jsConfig.contentTypes = mapContentToManifest(extractedContentTypes);
     }
 
     const restClient = await createApiClient(flags.host);

--- a/packages/optimizely-cms-cli/src/mapper/contentToPackage.ts
+++ b/packages/optimizely-cms-cli/src/mapper/contentToPackage.ts
@@ -1,0 +1,35 @@
+import { AnyContentType } from '../service/utils.js';
+
+export function mapContentToManifest(contentTypes: AnyContentType[]): any[] {
+  return contentTypes.map((contentType) => {
+    // Spread the contentType as extract properties
+    const { properties = {} } = contentType;
+
+    // Transform properties via a single reduce
+    const formattedProperties = Object.entries(properties).reduce(
+      (acc, [key, value]) => {
+        const updatedValue = { ...value };
+
+        // If type is "richText", we switch type to "string" and "format" to "html"
+        if (updatedValue.type === 'richText') {
+          (updatedValue.type as any) = 'string'; //
+          updatedValue.format = 'html';
+        }
+
+        // If "enum" exists, set format to "selectOne"
+        if (Object.hasOwn(updatedValue, 'enum')) {
+          updatedValue.format = 'selectOne';
+        }
+
+        acc[key] = updatedValue;
+        return acc;
+      },
+      {} as Record<string, any>
+    );
+
+    return {
+      ...contentType,
+      properties: formattedProperties,
+    };
+  });
+}

--- a/packages/optimizely-cms-cli/src/service/utils.ts
+++ b/packages/optimizely-cms-cli/src/service/utils.ts
@@ -8,19 +8,14 @@ export type Prettify<T> = {
 } & {};
 
 /** extract AnyContentType */
-type AllContentType = ContentTypes.AnyContentType;
+export type AnyContentType = ContentTypes.AnyContentType;
 
 export type FoundContentType = {
   path: string;
-  contentType: AllContentType;
+  contentType: AnyContentType;
 };
 
-/** Argument for `buildConfig` */
-export type Config = {
-  contentTypes?: AllContentType[] | string;
-};
-
-function isContentType(obj: unknown): obj is AllContentType {
+function isContentType(obj: unknown): obj is AnyContentType {
   return typeof obj === 'object' && obj !== null && 'key' in obj;
 }
 


### PR DESCRIPTION
- Add `mapContentToManifest` to map content to manifest or package object structure. This method handles `enum` and `richText` in properties.


### 1. Content with enum
```
export const ContentType = contentType({
  key: 'Hero',
  displayName: 'Hero',
  baseType: 'component',
  properties: {
    heading: {
      type: 'string',
    },
    summary: {
      type: 'string',
    },
    background: {
      type: 'contentReference',
      allowedTypes: ['Image'],
    },
    theme: {
      type: 'string',
      enum: {
        values: [
          { value: 'light', displayName: 'Light' },
          { value: 'dark', displayName: 'Dark' },
        ],
      },
    },
  },
  compositionBehaviors: ['sectionEnabled'],
});
```

The above content type will be  mapped to the following package/manifest structure. If a property consist of enum it will introduce `"format": "selectOne"`.

```
 {
      "key": "Hero",
      "displayName": "Hero",
      "baseType": "component",
      "properties": {
        "heading": {
          "type": "string"
        },
        "summary": {
          "type": "string"
        },
        "background": {
          "type": "contentReference",
          "allowedTypes": [
            "Image"
          ]
        },
        "theme": {
          "type": "string",
          "enum": {
            "values": [
              {
                "value": "light",
                "displayName": "Light"
              },
              {
                "value": "dark",
                "displayName": "Dark"
              }
            ]
          },
          "format": "selectOne"
        }
      },
      "compositionBehaviors": [
        "sectionEnabled"
      ]
    }
```


### 2. Content with type richText
```
export const ContentType = contentType({
  key: 'Article',
  displayName: 'Article',
  baseType: 'page',
  properties: {
    headline: {
      type: 'string',
    },
    thumbnail: {
      type: 'contentReference',
      allowedTypes: ['Image'],
    },
    body: {
      type: 'richText',
    },
  },
});
```

This will be mapped to the following manifest/project structure and will change the `type` from `richText` to   `"string` and add `"format": "html"`

```
{
    "key": "Article",
    "displayName": "Article",
    "baseType": "page",
    "properties": {
       "headline": {
         "type": "string"
       },
       "thumbnail": {
         "type": "contentReference",
         "allowedTypes": [
            "Image"
          ]
       },
      "body": {
        "type": "string",
        "format": "html"
      }
    }
  }
```