### PR TITLE
Feature/cms 41252 support display settings

### DIFF
--- a/packages/optimizely-cms-sdk/src/index.ts
+++ b/packages/optimizely-cms-sdk/src/index.ts
@@ -1,4 +1,10 @@
-export { contentType } from './model';
+export {
+  contentType,
+  displayTemplate,
+  isContentType,
+  isDisplayTemplate,
+} from './model';
 export * as ContentTypes from './model/contentTypes';
+export * as DisplayTemplates from './model/displayTemplates';
 export * as Properties from './model/properties';
 export { Infer } from './infer';

--- a/packages/optimizely-cms-sdk/src/model/displayTemplates.ts
+++ b/packages/optimizely-cms-sdk/src/model/displayTemplates.ts
@@ -18,6 +18,12 @@ type BaseTemplate = {
   nodeType?: never;
 };
 
+type WithContentType = {
+  contentType: string;
+  baseType?: never;
+  nodeType?: never;
+};
+
 type ChoiceType = Record<
   string,
   {
@@ -38,10 +44,10 @@ type SettingsType = Record<
 
 type BaseDisplayTemplate = {
   key: string;
-  displayName?: string;
+  displayName: string;
   isDefault: boolean;
   settings: SettingsType;
 };
 
 export type DisplayTemplate = BaseDisplayTemplate &
-  (NodeTemplate | BaseTemplate);
+  (NodeTemplate | BaseTemplate | WithContentType);

--- a/packages/optimizely-cms-sdk/src/model/index.ts
+++ b/packages/optimizely-cms-sdk/src/model/index.ts
@@ -2,11 +2,41 @@ import { AnyContentType } from './contentTypes';
 import { DisplayTemplate } from './displayTemplates';
 
 /** Defines a Optimizely CMS content type */
-export function contentType<T extends AnyContentType>(options: T): T {
-  return options;
+export function contentType<T extends AnyContentType>(
+  options: T
+): T & { __type: 'contentType' } {
+  return { ...options, __type: 'contentType' };
 }
 
 /** Defines a Optimizely CMS display template */
-export function displayTemplate<T extends DisplayTemplate>(options: T): T {
-  return options;
+export function displayTemplate<T extends DisplayTemplate>(
+  options: T
+): T & { __type: 'displayTemplate' } {
+  return { ...options, __type: 'displayTemplate' };
+}
+
+/**
+ * Checks if `obj` is a content type.
+ */
+export function isContentType(obj: unknown): obj is AnyContentType {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    '__type' in obj &&
+    (obj as any).__type === 'contentType' &&
+    'key' in obj
+  );
+}
+
+/**
+ * Checks if `obj` is a display template.
+ */
+export function isDisplayTemplate(obj: unknown): obj is DisplayTemplate {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    '__type' in obj &&
+    (obj as any).__type === 'displayTemplate' &&
+    'key' in obj
+  );
 }

--- a/samples/nextjs-template/src/components/LandingSection.tsx
+++ b/samples/nextjs-template/src/components/LandingSection.tsx
@@ -1,4 +1,4 @@
-import { contentType } from 'optimizely-cms-sdk';
+import { contentType, displayTemplate } from 'optimizely-cms-sdk';
 
 export const ContentType = contentType({
   key: 'LandingSection',
@@ -15,7 +15,31 @@ export const ContentType = contentType({
       type: 'array',
       items: {
         type: 'content',
-        allowedTypes: ['SmallFeatureGrid', 'VideoFeature'],
+        allowedTypes: ['SmallFeatureGrid'],
+      },
+    },
+  },
+});
+
+export const DisplayTemplate = displayTemplate({
+  key: 'LandingSectionDisplayTemplate',
+  isDefault: true,
+  displayName: 'LandingSectionDisplayTemplate',
+  contentType: 'LandingSection',
+  settings: {
+    background: {
+      editor: 'select',
+      displayName: 'Background',
+      sortOrder: 0,
+      choices: {
+        red: {
+          displayName: 'Red',
+          sortOrder: 0,
+        },
+        blue: {
+          displayName: 'Blue',
+          sortOrder: 1,
+        },
       },
     },
   },


### PR DESCRIPTION
This PR adds methods to create, map and push displayTemplates to CMS instance.

- Updated `findContentTypes` (now `findMetaData`) to handle display templates.
- Added types to for DisplayTemplates