### PR TITLE
Create DisplayTemplateRegistry and parseDisplaySettings method

### DIFF
--- a/packages/optimizely-cms-sdk/src/index.ts
+++ b/packages/optimizely-cms-sdk/src/index.ts
@@ -6,6 +6,7 @@ export {
   isContentType,
   isDisplayTemplate,
   initContentTypeRegistry,
+  initDisplayTemplateRegistry,
 } from './model/index.js';
 export { GraphClient, getFilterFromPath } from './graph/index.js';
 export { createQuery } from './graph/createQuery.js';

--- a/packages/optimizely-cms-sdk/src/infer.ts
+++ b/packages/optimizely-cms-sdk/src/infer.ts
@@ -80,6 +80,11 @@ type InferProps<T extends AnyContentType> = T extends {
 // Special fields for Experience
 export type ExperienceNode = ExperienceComponentNode | ExperienceStructureNode;
 
+export type DisplaySettingsType = {
+  key: string;
+  value: string;
+};
+
 export type ExperienceCompositionNode = {
   /** Internal node type. Can be `CompositionStructureNode` or `CompositionComponentNode` */
   __typename: string;
@@ -90,10 +95,8 @@ export type ExperienceCompositionNode = {
 
   key: string;
   displayName: string;
-  displaySettings: {
-    key: string;
-    value: string;
-  }[];
+  displayTemplateKey: string;
+  displaySettings: DisplaySettingsType[];
 };
 
 export type ExperienceStructureNode = ExperienceCompositionNode & {

--- a/packages/optimizely-cms-sdk/src/model/__test__/parseDisplaySettings.test.ts
+++ b/packages/optimizely-cms-sdk/src/model/__test__/parseDisplaySettings.test.ts
@@ -19,7 +19,6 @@ describe('parseDisplaySettings', () => {
     const result = parseDisplaySettings(input);
     expect(result).toEqual({
       layout: 'grid',
-      theme: undefined,
     });
   });
 

--- a/packages/optimizely-cms-sdk/src/model/__test__/parseDisplaySettings.test.ts
+++ b/packages/optimizely-cms-sdk/src/model/__test__/parseDisplaySettings.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { parseDisplaySettings } from '../displayTemplates.js';
+
+describe('parseDisplaySettings', () => {
+  it('should parse valid display settings correctly', () => {
+    const input = [
+      { key: 'layout', value: 'grid' },
+      { key: 'theme', value: 'dark' },
+    ];
+    const result = parseDisplaySettings(input);
+    expect(result).toEqual({
+      layout: 'grid',
+      theme: 'dark',
+    });
+  });
+
+  it('should handle missing properties gracefully', () => {
+    const input = [{ key: 'layout', value: 'grid' }];
+    const result = parseDisplaySettings(input);
+    expect(result).toEqual({
+      layout: 'grid',
+      theme: undefined,
+    });
+  });
+
+  it('should return an empty object for null input', () => {
+    const input = null;
+    const result = parseDisplaySettings(input ?? undefined);
+    expect(result).toEqual(undefined);
+  });
+
+  it('should return an empty object for undefined input', () => {
+    const input = undefined;
+    const result = parseDisplaySettings(input);
+    expect(result).toEqual(undefined);
+  });
+});

--- a/packages/optimizely-cms-sdk/src/model/displayTemplateRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/model/displayTemplateRegistry.ts
@@ -20,7 +20,7 @@ export function getDisplayTemplateTag(
 }
 
 /** Get all the DisplayTemplates */
-export function getAllisplayTemplates(): DisplayTemplate[] {
+export function getAllDisplayTemplates(): DisplayTemplate[] {
   return _registry;
 }
 

--- a/packages/optimizely-cms-sdk/src/model/displayTemplateRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/model/displayTemplateRegistry.ts
@@ -1,0 +1,30 @@
+import { DisplayTemplate } from './displayTemplates.js';
+
+let _registry: DisplayTemplate[] = [];
+
+/** Initializes the content type registry */
+export function init(registry: DisplayTemplate[]) {
+  _registry = registry;
+}
+
+/** Get the DisplayTemplate from a template name */
+export function getDisplayTemplate(name: string) {
+  return _registry.find((c) => c.key === name);
+}
+
+/** Get the Component name from a content type name */
+export function getDisplayTemplateTag(
+  name: string | undefined
+): string | undefined {
+  return _registry.find((c) => c.key === name)?.tag;
+}
+
+/** Get all the DisplayTemplates */
+export function getAllisplayTemplates(): DisplayTemplate[] {
+  return _registry;
+}
+
+/** Get the DisplayTemplate from a tag */
+export function getDisplayTemplateByTag(tag: string): DisplayTemplate[] {
+  return _registry.filter((c) => c.tag === tag) as DisplayTemplate[];
+}

--- a/packages/optimizely-cms-sdk/src/model/displayTemplates.ts
+++ b/packages/optimizely-cms-sdk/src/model/displayTemplates.ts
@@ -1,10 +1,15 @@
-import { AnyContentType } from './contentTypes.js';
+import { DisplaySettingsType } from '../infer.js';
+import { BaseTypes } from './contentTypes.js';
 
-type NodeType = 'row' | 'column';
+// section node types
+export const NODE_TYPES = ['row', 'column'] as const;
 
-type EditorType = 'select' | 'checkbox';
+// cms editor types
+export const EDITOR_TYPE = ['select', 'checkbox'] as const;
 
-type BaseType = AnyContentType['baseType'];
+type NodeType = (typeof NODE_TYPES)[number];
+
+type EditorType = (typeof EDITOR_TYPE)[number];
 
 type NodeTemplate = {
   nodeType: NodeType;
@@ -13,7 +18,7 @@ type NodeTemplate = {
 };
 
 type BaseTemplate = {
-  baseType: BaseType;
+  baseType: BaseTypes | '_component';
   contentType?: never;
   nodeType?: never;
 };
@@ -47,7 +52,30 @@ type BaseDisplayTemplate = {
   displayName: string;
   isDefault: boolean;
   settings: SettingsType;
+  tag?: string; // Optional tag property to store the name of the React component
 };
 
-export type DisplayTemplate = BaseDisplayTemplate &
+export type DisplayTemplateVariant = BaseDisplayTemplate &
   (NodeTemplate | BaseTemplate | WithContentType);
+
+export type DisplayTemplate<T = DisplayTemplateVariant> = T & {
+  __type: 'displayTemplate';
+};
+
+export function parseDisplaySettings(
+  displaySettings?: DisplaySettingsType[]
+): Record<string, string> | undefined {
+  if (!displaySettings) {
+    return undefined; // Return undefined if displaySettings is not provided
+  }
+
+  const result: Record<string, string> = {}; // Initialize an empty object
+
+  // Iterate over the input array
+  for (const item of displaySettings) {
+    // Assign the value to the key in the result object
+    result[item.key] = item.value;
+  }
+
+  return result;
+}

--- a/packages/optimizely-cms-sdk/src/model/index.ts
+++ b/packages/optimizely-cms-sdk/src/model/index.ts
@@ -1,6 +1,6 @@
 import { BuildConfig } from './buildConfig.js';
 import { AnyContentType } from './contentTypes.js';
-import { DisplayTemplate } from './displayTemplates.js';
+import { DisplayTemplate, DisplayTemplateVariant } from './displayTemplates.js';
 
 /** Defines a Optimizely CMS content type */
 export function contentType<T extends AnyContentType>(
@@ -10,7 +10,7 @@ export function contentType<T extends AnyContentType>(
 }
 
 /** Defines a Optimizely CMS display template */
-export function displayTemplate<T extends DisplayTemplate>(
+export function displayTemplate<T extends DisplayTemplateVariant>(
   options: T
 ): T & { __type: 'displayTemplate' } {
   return { ...options, __type: 'displayTemplate' };
@@ -50,3 +50,4 @@ export function isDisplayTemplate(obj: unknown): obj is DisplayTemplate {
 }
 
 export { init as initContentTypeRegistry } from './contentTypeRegistry.js';
+export { init as initDisplayTemplateRegistry } from './displayTemplateRegistry.js';

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -34,11 +34,13 @@ type Props = {
     __context?: { edit: boolean; preview_token: string };
   };
   componentKey?: string;
+  displaySettings?: Record<string, string>;
 };
 
 export async function OptimizelyComponent({
   opti,
   componentKey,
+  displaySettings,
   ...props
 }: Props) {
   if (!componentRegistry) {
@@ -56,7 +58,9 @@ export async function OptimizelyComponent({
     ...opti,
   };
 
-  return <Component opti={optiProps} {...props} />;
+  return (
+    <Component opti={optiProps} {...props} displaySettings={displaySettings} />
+  );
 }
 
 export type StructureContainerProps = {
@@ -145,6 +149,8 @@ export function OptimizelyGridSection({
   return nodes.map((node, i) => {
     // get component key(tag) from the display template
     const key = getDisplayTemplateTag(node.displayTemplateKey);
+    // get the parsed display settings (stlyes, classes etc.)
+    const parsedDisplaySettings = parseDisplaySettings(node.displaySettings);
 
     if (isComponentNode(node)) {
       return (
@@ -152,6 +158,7 @@ export function OptimizelyGridSection({
           key={node.key}
           opti={node.component}
           componentKey={key}
+          displaySettings={parsedDisplaySettings}
         />
       );
     }
@@ -162,8 +169,6 @@ export function OptimizelyGridSection({
 
     // TODO: default component
     const Component = mapper[nodeType] ?? React.Fragment;
-    // get the parsed display settings (stlyes, classes etc.)
-    const parsedDisplaySettings = parseDisplaySettings(node.displaySettings);
 
     return (
       <Component

--- a/samples/nextjs-template/src/app/globals.css
+++ b/samples/nextjs-template/src/app/globals.css
@@ -559,6 +559,34 @@ a:hover span.animate {
   margin: 0;
 }
 
+.squarTile {
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+  padding: 2rem;
+  background: white;
+  border-radius: 0; /* Changed to square edges */
+  border: 1px solid #ddd;
+  background-color: #ffffff;
+  min-height: 240px;
+}
+
+.squarTile h1 {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #333;
+  margin: 0;
+}
+
+.squarTile p {
+  font-size: 1rem;
+  color: #555;
+  margin: 0;
+}
+
 .about-us {
   display: flex;
   flex-direction: column;

--- a/samples/nextjs-template/src/app/layout.tsx
+++ b/samples/nextjs-template/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import {
   BlankExperienceContentType,
   initContentTypeRegistry,
+  initDisplayTemplateRegistry,
 } from '@episerver/cms-sdk';
 import { initReactComponentRegistry } from '@episerver/cms-sdk/react/server';
 
@@ -13,6 +14,7 @@ import Landing, {
 } from '@/components/Landing';
 import LandingSection, {
   LandingSectionContentType,
+  LandingSectionDisplayTemplate,
 } from '@/components/LandingSection';
 import SmallFeatureGrid, {
   SmallFeatureGridContentType,
@@ -97,6 +99,8 @@ initReactComponentRegistry({
     BlankExperience,
   },
 });
+
+initDisplayTemplateRegistry([LandingSectionDisplayTemplate]);
 
 const serifFont = Bodoni_Moda({
   variable: '--font-serif',

--- a/samples/nextjs-template/src/app/layout.tsx
+++ b/samples/nextjs-template/src/app/layout.tsx
@@ -39,7 +39,13 @@ import BlogExperience, {
 } from '@/components/BlogExperience';
 import BlogCard, { BlogCardContentType } from '@/components/BlogCard';
 import Banner, { BannerContentType } from '@/components/Banner';
-import Tile, { TileContentType } from '@/components/Tile';
+import Tile, {
+  SquarTile,
+  SquarTileDisplayTemplate,
+  TileColumnDisplayTemplate,
+  TileContentType,
+  TileRowDisplayTemplate,
+} from '@/components/Tile';
 import AboutExperience, {
   AboutExperienceContentType,
 } from '@/components/AboutExperience';
@@ -97,10 +103,16 @@ initReactComponentRegistry({
     OfficeLocations,
     Location,
     BlankExperience,
+    SquarTile,
   },
 });
 
-initDisplayTemplateRegistry([LandingSectionDisplayTemplate]);
+initDisplayTemplateRegistry([
+  TileRowDisplayTemplate,
+  TileColumnDisplayTemplate,
+  LandingSectionDisplayTemplate,
+  SquarTileDisplayTemplate,
+]);
 
 const serifFont = Bodoni_Moda({
   variable: '--font-serif',

--- a/samples/nextjs-template/src/components/LandingSection.tsx
+++ b/samples/nextjs-template/src/components/LandingSection.tsx
@@ -28,7 +28,7 @@ export const LandingSectionContentType = contentType({
   compositionBehaviors: ['sectionEnabled'],
 });
 
-export const DisplayTemplate = displayTemplate({
+export const LandingSectionDisplayTemplate = displayTemplate({
   key: 'LandingSectionDisplayTemplate',
   isDefault: true,
   displayName: 'LandingSectionDisplayTemplate',
@@ -50,6 +50,7 @@ export const DisplayTemplate = displayTemplate({
       },
     },
   },
+  tag: LandingSection.name,
 });
 
 type Props = {

--- a/samples/nextjs-template/src/components/LandingSection.tsx
+++ b/samples/nextjs-template/src/components/LandingSection.tsx
@@ -50,7 +50,6 @@ export const LandingSectionDisplayTemplate = displayTemplate({
       },
     },
   },
-  tag: LandingSection.name,
 });
 
 type Props = {

--- a/samples/nextjs-template/src/components/Tile.tsx
+++ b/samples/nextjs-template/src/components/Tile.tsx
@@ -1,4 +1,4 @@
-import { contentType, Infer } from '@episerver/cms-sdk';
+import { contentType, displayTemplate, Infer } from '@episerver/cms-sdk';
 
 export const TileContentType = contentType({
   key: 'Tile',
@@ -15,6 +15,62 @@ export const TileContentType = contentType({
   compositionBehaviors: ['elementEnabled'],
 });
 
+export const TileRowDisplayTemplate = displayTemplate({
+  key: 'TileRowDisplayTemplate',
+  isDefault: true,
+  displayName: 'TileRowDisplayTemplate',
+  nodeType: 'row',
+  settings: {
+    padding: {
+      editor: 'select',
+      displayName: 'Padding',
+      sortOrder: 0,
+      choices: {
+        small: {
+          displayName: 'Small',
+          sortOrder: 1,
+        },
+        medium: {
+          displayName: 'Medium',
+          sortOrder: 2,
+        },
+        large: {
+          displayName: 'Large',
+          sortOrder: 3,
+        },
+      },
+    },
+  },
+});
+
+export const TileColumnDisplayTemplate = displayTemplate({
+  key: 'TileColumnDisplayTemplate',
+  isDefault: true,
+  displayName: 'TileColumnDisplayTemplate',
+  nodeType: 'column',
+  settings: {
+    background: {
+      editor: 'select',
+      displayName: 'Background Color',
+      sortOrder: 0,
+      choices: {
+        red: {
+          displayName: 'Red',
+          sortOrder: 1,
+        },
+        black: {
+          displayName: 'Black',
+          sortOrder: 2,
+        },
+        grey: {
+          displayName: 'Grey',
+          sortOrder: 3,
+        },
+      },
+    },
+  },
+});
+
 type Props = {
   opti: Infer<typeof TileContentType>;
 };
@@ -22,7 +78,18 @@ type Props = {
 export default function Tile({ opti }: Props) {
   return (
     <div className="tile">
+      <div>Base Tile</div>
       <h1>{opti.title}</h1>
+      <p>{opti.description}</p>
+    </div>
+  );
+}
+
+export function TileA({ opti }: Props) {
+  return (
+    <div className="tile">
+      <div>TileA</div>
+      <h4>{opti.title}</h4>
       <p>{opti.description}</p>
     </div>
   );

--- a/samples/nextjs-template/src/components/Tile.tsx
+++ b/samples/nextjs-template/src/components/Tile.tsx
@@ -71,26 +71,55 @@ export const TileColumnDisplayTemplate = displayTemplate({
   },
 });
 
+export const SquarTileDisplayTemplate = displayTemplate({
+  key: 'SquarTileDisplayTemplate',
+  isDefault: false,
+  displayName: 'SquarTileDisplayTemplate',
+  baseType: '_component',
+  settings: {
+    color: {
+      editor: 'select',
+      displayName: 'Description font color',
+      sortOrder: 0,
+      choices: {
+        yellow: {
+          displayName: 'Yellow',
+          sortOrder: 1,
+        },
+        green: {
+          displayName: 'Green',
+          sortOrder: 2,
+        },
+        orange: {
+          displayName: 'Orange',
+          sortOrder: 3,
+        },
+      },
+    },
+  },
+  tag: SquarTile.name,
+});
+
 type Props = {
   opti: Infer<typeof TileContentType>;
+  displaySettings?: Record<string, string>;
 };
 
 export default function Tile({ opti }: Props) {
   return (
     <div className="tile">
-      <div>Base Tile</div>
       <h1>{opti.title}</h1>
       <p>{opti.description}</p>
     </div>
   );
 }
 
-export function TileA({ opti }: Props) {
+// This is a specific tile component that uses the SquarTileDisplayTemplate
+export function SquarTile({ opti, displaySettings }: Props) {
   return (
-    <div className="tile">
-      <div>TileA</div>
+    <div className="squarTile">
       <h4>{opti.title}</h4>
-      <p>{opti.description}</p>
+      <p style={{ color: displaySettings?.color }}>{opti.description}</p>
     </div>
   );
 }


### PR DESCRIPTION
- Creates a registry for `DisplayTemplates` to allow SDK to map `DisplayTemplates` with `DisplayTemplateKey`.
- Add method to parse `DisplaySettings` to more readable format.