### PR TITLE
Reuse display template tags

### DIFF
--- a/__test__/test-website/.gitignore
+++ b/__test__/test-website/.gitignore
@@ -1,0 +1,43 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+certificates

--- a/__test__/test-website/README.md
+++ b/__test__/test-website/README.md
@@ -1,0 +1,3 @@
+# Test website
+
+This project is a website built with Next.js to test SDK and CLI features against an actual CMS.

--- a/__test__/test-website/next.config.ts
+++ b/__test__/test-website/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;

--- a/__test__/test-website/package.json
+++ b/__test__/test-website/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "test-website",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --experimental-https",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "@episerver/cms-cli": "workspace:*",
+    "@episerver/cms-sdk": "workspace:*",
+    "next": "15.4.5"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19"
+  }
+}

--- a/__test__/test-website/src/app/[...slug]/page.tsx
+++ b/__test__/test-website/src/app/[...slug]/page.tsx
@@ -1,0 +1,20 @@
+import { GraphClient } from '@episerver/cms-sdk';
+import { OptimizelyComponent } from '@episerver/cms-sdk/react/server';
+import React from 'react';
+
+type Props = {
+  params: Promise<{
+    slug: string[];
+  }>;
+};
+
+export default async function Page({ params }: Props) {
+  const { slug } = await params;
+
+  const client = new GraphClient(process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!, {
+    graphUrl: process.env.OPTIMIZELY_GRAPH_URL,
+  });
+  const c = await client.fetchContent(`/${slug.join('/')}/`);
+
+  return <OptimizelyComponent opti={c} />;
+}

--- a/__test__/test-website/src/app/layout.tsx
+++ b/__test__/test-website/src/app/layout.tsx
@@ -1,0 +1,49 @@
+import {
+  BlankSection,
+  Component1,
+  Component1A,
+  Component1B,
+  Component2,
+  Component2A,
+  Component3,
+  ct1,
+  ct2,
+  ct3,
+  dt1,
+  dt2,
+} from '@/components/with-display-templates';
+import {
+  initContentTypeRegistry,
+  initDisplayTemplateRegistry,
+} from '@episerver/cms-sdk';
+import { initReactComponentRegistry } from '@episerver/cms-sdk/react/server';
+
+initContentTypeRegistry([ct1, ct2, ct3]);
+initDisplayTemplateRegistry([dt1, dt2]);
+initReactComponentRegistry({
+  resolver: {
+    test_c1: {
+      default: Component1,
+      tags: {
+        tagA: Component1A,
+        tagB: Component1B,
+      },
+    },
+    test_c2: Component2,
+    'test_c2:tagA': Component2A,
+    test_c3: Component3,
+    BlankSection: BlankSection,
+  },
+});
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/__test__/test-website/src/app/preview/page.tsx
+++ b/__test__/test-website/src/app/preview/page.tsx
@@ -1,0 +1,31 @@
+import { GraphClient, type PreviewParams } from '@episerver/cms-sdk';
+import { OptimizelyComponent } from '@episerver/cms-sdk/react/server';
+import { PreviewComponent } from '@episerver/cms-sdk/react/client';
+import Script from 'next/script';
+
+type Props = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+export default async function Page({ searchParams }: Props) {
+  const client = new GraphClient(process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!, {
+    graphUrl: process.env.OPTIMIZELY_GRAPH_URL,
+  });
+
+  const response = await client.fetchPreviewContent(
+    // TODO: check types in runtime properly
+    (await searchParams) as PreviewParams
+  );
+
+  console.log(response);
+
+  return (
+    <>
+      <Script
+        src={`${process.env.OPTIMIZELY_CMS_HOST}/util/javascript/communicationinjector.js`}
+      ></Script>
+      <PreviewComponent />
+      <OptimizelyComponent opti={response} />
+    </>
+  );
+}

--- a/__test__/test-website/src/app/preview/page.tsx
+++ b/__test__/test-website/src/app/preview/page.tsx
@@ -17,8 +17,6 @@ export default async function Page({ searchParams }: Props) {
     (await searchParams) as PreviewParams
   );
 
-  console.log(response);
-
   return (
     <>
       <Script

--- a/__test__/test-website/src/components/with-display-templates.tsx
+++ b/__test__/test-website/src/components/with-display-templates.tsx
@@ -1,0 +1,116 @@
+import {
+  BlankSectionContentType,
+  contentType,
+  displayTemplate,
+  Infer,
+} from '@episerver/cms-sdk';
+import {
+  OptimizelyExperience,
+  OptimizelyGridSection,
+  StructureContainerProps,
+} from '@episerver/cms-sdk/react/server';
+
+export const ct1 = contentType({
+  key: 'test_c1',
+  baseType: '_component',
+  properties: {
+    p1: { type: 'string' },
+  },
+  compositionBehaviors: ['elementEnabled', 'sectionEnabled'],
+});
+
+export const ct2 = contentType({
+  key: 'test_c2',
+  baseType: '_component',
+  properties: {
+    p2: { type: 'float' },
+  },
+  compositionBehaviors: ['elementEnabled', 'sectionEnabled'],
+});
+
+export const ct3 = contentType({
+  key: 'test_c3',
+  baseType: '_experience',
+});
+
+export const dt1 = displayTemplate({
+  key: 'test_dt1',
+  baseType: '_component',
+  displayName: 'test dt1',
+  isDefault: false,
+  settings: {},
+  tag: 'tagA',
+});
+
+export const dt2 = displayTemplate({
+  key: 'test_dt2',
+  baseType: '_component',
+  displayName: 'test dt2',
+  isDefault: false,
+  settings: {},
+  tag: 'tagB',
+});
+
+type Props1 = { opti: Infer<typeof ct1> };
+type Props2 = { opti: Infer<typeof ct2> };
+type Props3 = { opti: Infer<typeof ct3> };
+
+type BlankSectionProps = {
+  opti: Infer<typeof BlankSectionContentType>;
+};
+
+export function Component1({ opti }: Props1) {
+  return <div>This is Component1. p1: {opti.p1}</div>;
+}
+
+export function Component1A({ opti }: Props1) {
+  return <div>This is Component1A. p1: {opti.p1}</div>;
+}
+
+export function Component1B({ opti }: Props1) {
+  return <div>This is Component1B. p1: {opti.p1}</div>;
+}
+
+export function Component2({ opti }: Props2) {
+  return <div>This is Component2. p2: {opti.p2}</div>;
+}
+
+export function Component2A({ opti }: Props2) {
+  return <div>This is Component2A. p2: {opti.p2}</div>;
+}
+
+export function Component3({ opti }: Props3) {
+  return (
+    <div>
+      <h1>This is an experience</h1>
+      <OptimizelyExperience nodes={opti.composition.nodes ?? []} />
+    </div>
+  );
+}
+
+function Row({ children, node }: StructureContainerProps) {
+  return (
+    <>
+      <h3>This is row {node.key}</h3>
+      {children}
+    </>
+  );
+}
+
+function Column({ children, node }: StructureContainerProps) {
+  return (
+    <>
+      <h4>This is column {node.key}</h4>
+      {children}
+    </>
+  );
+}
+
+export function BlankSection({ opti }: BlankSectionProps) {
+  return (
+    <>
+      <h2>This is section {opti.key}</h2>
+      <OptimizelyGridSection nodes={opti.nodes} row={Row} column={Column} />
+    </>
+  );
+}

--- a/__test__/test-website/tsconfig.json
+++ b/__test__/test-website/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/__test__/test-website/with-display-templates.config.mjs
+++ b/__test__/test-website/with-display-templates.config.mjs
@@ -1,0 +1,5 @@
+import { buildConfig } from '@episerver/cms-sdk';
+
+export default buildConfig({
+  components: ['./src/components/with-display-templates.tsx'],
+});

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -153,8 +153,8 @@ export class GraphClient {
     if (!contentTypeName) {
       throw new Error(`No content found for key [${params.key}]`);
     }
-
     const query = createQuery(contentTypeName);
+
     const response = await this.request(
       query,
       { filter },

--- a/packages/optimizely-cms-sdk/src/model/displayTemplateRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/model/displayTemplateRegistry.ts
@@ -12,11 +12,14 @@ export function getDisplayTemplate(name: string) {
   return _registry.find((c) => c.key === name);
 }
 
-/** Get the Component name from a content type name */
-export function getDisplayTemplateTag(
-  name: string | undefined
-): string | undefined {
-  return _registry.find((c) => c.key === name)?.tag;
+/**
+ * Get the tag of a {@linkcode DisplayTemplate}. Returns undefined if
+ * the DisplayTemplate doesn't exist or it doesn't have any tag
+ *
+ * @param key DisplayTemplate's key
+ */
+export function getDisplayTemplateTag(key: string): string | undefined {
+  return getDisplayTemplate(key)?.tag;
 }
 
 /** Get all the DisplayTemplates */

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -149,7 +149,6 @@ export function OptimizelyExperience({
           displaySettings={parsedDisplaySettings}
         >
           <OptimizelyComponent
-            key={node.key}
             opti={{
               ...node.component,
               __tag: tag,

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -28,30 +28,38 @@ export function initReactComponentRegistry(options: InitOptions) {
   componentRegistry = new ComponentRegistry(options.resolver);
 }
 
-type Props = {
+/** Props for the {@linkcode OptimizelyComponent} component */
+type OptimizelyComponentProps = {
+  /** Data read from the CMS */
   opti: {
+    /** Content type name */
     __typename: string;
+
+    /** Display template tag (if any) */
+    __tag?: string;
+
+    /** Preview context */
     __context?: { edit: boolean; preview_token: string };
   };
-  componentKey?: string;
+
   displaySettings?: Record<string, string>;
 };
 
 export async function OptimizelyComponent({
   opti,
-  componentKey,
   displaySettings,
   ...props
-}: Props) {
+}: OptimizelyComponentProps) {
   if (!componentRegistry) {
     throw new Error('You should call `initReactComponentRegistry` first');
   }
 
-  const contentType = componentKey ?? opti.__typename;
-  const Component = await componentRegistry.getComponent(contentType);
+  const Component = await componentRegistry.getComponent(opti.__typename, {
+    tag: opti.__tag,
+  });
 
   if (!Component) {
-    return <div>No component found for content type {contentType}</div>;
+    return <div>No component found for content type {opti.__typename}</div>;
   }
 
   const optiProps = {
@@ -89,20 +97,26 @@ export function OptimizelyExperience({
   ComponentWrapper?: ComponentContainer;
 }) {
   return nodes.map((node) => {
-    // get component key(tag) from the display template
-    const key = getDisplayTemplateTag(node.displayTemplateKey);
-    // get the parsed display settings (stlyes, classes etc.)
+    const tag = getDisplayTemplateTag(node.displayTemplateKey);
     const parsedDisplaySettings = parseDisplaySettings(node.displaySettings);
 
     if (isComponentNode(node)) {
       const Wrapper = ComponentWrapper ?? React.Fragment;
+
       return (
         <Wrapper
           node={node}
           key={node.key}
           displaySettings={parsedDisplaySettings}
         >
-          <OptimizelyComponent opti={node.component} componentKey={key} />
+          <OptimizelyComponent
+            key={node.key}
+            opti={{
+              ...node.component,
+              __typename: node.nodeType,
+              __tag: tag,
+            }}
+          />
         </Wrapper>
       );
     }
@@ -114,18 +128,14 @@ export function OptimizelyExperience({
       return <div>???</div>;
     }
 
-    // If a display template key is provided, use it to retrieve the corresponding component.
-    // Otherwise, fall back to using the node type as the key to identify the component.
-    const Component = componentRegistry.getComponent(key ?? type);
-
-    if (!Component) {
-      throw new Error(`No component defined for content type ${type}`);
-    }
-
     return (
-      <Component
+      <OptimizelyComponent
         key={node.key}
-        opti={node}
+        opti={{
+          ...node,
+          __typename: type,
+          __tag: tag,
+        }}
         displaySettings={parsedDisplaySettings}
       />
     );
@@ -155,9 +165,11 @@ export function OptimizelyGridSection({
     if (isComponentNode(node)) {
       return (
         <OptimizelyComponent
+          opti={{
+            ...node.component,
+            __tag: key,
+          }}
           key={node.key}
-          opti={node.component}
-          componentKey={key}
           displaySettings={parsedDisplaySettings}
         />
       );
@@ -184,7 +196,7 @@ export function OptimizelyGridSection({
 }
 
 /** Get context-aware functions for preview */
-export function getPreviewUtils(opti: Props['opti']) {
+export function getPreviewUtils(opti: OptimizelyComponentProps['opti']) {
   return {
     /** Get the HTML data attributes required for a property */
     pa(property: string | { key: string }) {

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   ComponentRegistry,
-  ComponentResolver,
+  ComponentResolverOrObject,
 } from '../render/componentRegistry.js';
 import { JSX } from 'react';
 import {
@@ -21,9 +21,48 @@ type ComponentType = React.ComponentType<any>;
 let componentRegistry: ComponentRegistry<ComponentType>;
 
 type InitOptions = {
-  resolver: ComponentResolver<ComponentType>;
+  resolver: ComponentResolverOrObject<ComponentType>;
 };
 
+/**
+ * Initializes the React component registry
+ *
+ * @param options Initialization options.
+ * @param options.resolver Either a ComponentResolver function for dynamic resolution,
+ * or a ComponentMap object for static mappings between content types and components
+ *
+ *
+ * @example
+ * Using a static component map:
+ *
+ * ```ts
+ * initReactComponentRegistry({
+ *   resolver: {
+ *     'ButtonContentType': ButtonComponent,
+ *     // You can define tags using the `ContentType:Tag` syntax:
+ *     'ButtonContentType:ChristmasTag': ChristmasButtonComponent,
+ *     'CardContentType': {
+ *       default: DefaultCardComponent,
+ *       tags: { ChristmasTag: ChristmasCardComponent }
+ *     }
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * Using a dynamic resolver function:
+ *
+ * ```ts
+ * initReactComponentRegistry({
+ *   resolver: (contentType, options) => {
+ *     if (contentType === 'Button') {
+ *       return options?.tag === 'primary' ? PrimaryButton : DefaultButton;
+ *     }
+ *     return undefined;
+ *   }
+ * });
+ * ```
+ */
 export function initReactComponentRegistry(options: InitOptions) {
   componentRegistry = new ComponentRegistry(options.resolver);
 }

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -152,7 +152,6 @@ export function OptimizelyExperience({
             key={node.key}
             opti={{
               ...node.component,
-              __typename: node.nodeType,
               __tag: tag,
             }}
           />

--- a/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
@@ -1,13 +1,37 @@
-export type ComponentResolver<C> =
-  | Record<string, C>
-  | ((contentType: string) => C);
+/** Definition of one ContentType to Component mapping */
+type ComponentFullDefinition<C> = {
+  default: C;
+  tags: Record<string, C>;
+};
+
+/** Optional arguments to resolve a component */
+type ResolverOptions = {
+  tag: string;
+};
+
+/** Function that returns a component given a content type name and options */
+type ComponentResolver<C> = (
+  contentType: string,
+  options?: ResolverOptions
+) => C;
+
+/** Maps a content type name to a component */
+type ComponentMap<C> = Record<string, C | ComponentFullDefinition<C>>;
+
+export type ComponentResolverOrObject<C> =
+  | ComponentResolver<C>
+  | ComponentMap<C>;
 
 /** A registry mapping content type names and components */
 export class ComponentRegistry<T> {
-  resolver: ComponentResolver<T>;
+  resolver: ComponentResolverOrObject<T>;
 
-  constructor(resolver: ComponentResolver<T>) {
-    this.resolver = resolver;
+  /**
+   * Initializes the component registry
+   *
+   */
+  constructor(resolverOrObject: ComponentResolverOrObject<T>) {
+    this.resolver = resolverOrObject;
   }
 
   /** Returns the component given its content type name. Returns `undefined` if not found */

--- a/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
@@ -1,23 +1,80 @@
-/** Definition of one ContentType to Component mapping */
-type ComponentFullDefinition<C> = {
+/**
+ * This module defines a {@linkcode ComponentRegistry}, a mapping between Optimizely CMS content types and
+ * frontend Components (React components, Vue components, etc.)
+ *
+ * To define the `ComponentRegistry`, developers can provide a {@linkcode ComponentMap} object or a
+ * {@linkcode ComponentResolver} function
+ *
+ * @module
+ */
+
+/**
+ * A component definition that includes a default component and optional
+ * tagged variants
+ */
+type ComponentWithVariants<C> = {
+  /** Default component */
   default: C;
+
+  /** Tagged variants */
   tags: Record<string, C>;
 };
 
+/** A component entry that can be a single component or a component with tagged variants  */
+type ComponentEntry<C> = C | ComponentWithVariants<C>;
+
 /** Optional arguments to resolve a component */
 type ResolverOptions = {
-  tag: string;
+  tag?: string;
 };
 
-/** Function that returns a component given a content type name and options */
+/**
+ * A function that dynamically resolves components based on content type and options.
+ *
+ * This provides a flexible alternative to static component mappings, allowing you to
+ * implement custom logic for component resolution, such as lazy loading, conditional
+ * rendering, or dynamic imports.
+ */
 type ComponentResolver<C> = (
   contentType: string,
   options?: ResolverOptions
-) => C;
+) => C | undefined;
 
-/** Maps a content type name to a component */
-type ComponentMap<C> = Record<string, C | ComponentFullDefinition<C>>;
+/** Object mapping a content type name to a {@linkcode ComponentEntry} */
+type ComponentMap<C> = Record<string, ComponentEntry<C>>;
 
+/** Returns true if `obj` is type {@linkcode ComponentWithVariants} */
+function hasVariants<T>(obj: unknown): obj is ComponentWithVariants<T> {
+  return (
+    typeof obj === 'object' && obj !== null && 'default' in obj && 'tags' in obj
+  );
+}
+
+/** Returns the default component in an {@linkcode ComponentEntry} */
+function getDefaultComponent<C>(entry: ComponentEntry<C>): C {
+  if (hasVariants(entry)) {
+    return entry.default;
+  } else {
+    return entry;
+  }
+}
+
+/** Returns a component matching a tag in a {@linkcode ComponentEntry} */
+function getTagComponent<C>(
+  entry: ComponentEntry<C>,
+  tag: string
+): C | undefined {
+  if (!hasVariants(entry)) {
+    return undefined;
+  }
+
+  return entry.tags[tag];
+}
+
+/**
+ * Defines the component resolver as a function {@linkcode ComponentResolver}
+ * or as an object {@linkcode ComponentMap}
+ */
 export type ComponentResolverOrObject<C> =
   | ComponentResolver<C>
   | ComponentMap<C>;
@@ -27,19 +84,73 @@ export class ComponentRegistry<T> {
   resolver: ComponentResolverOrObject<T>;
 
   /**
-   * Initializes the component registry
+   * Creates a new ComponentRegistry instance.
    *
+   * @param resolverOrObject - Either a ComponentResolver function for dynamic resolution,
+   *   or a ComponentMap object for static mappings between content types and components
+   *
+   * @example
+   * Using a static component map:
+   *
+   * ```ts
+   * const registry = new ComponentRegistry({
+   *   'ButtonContentType': ButtonComponent,
+   *   // You can define tags using the `ContentType:Tag` syntax:
+   *   'ButtonContentType:ChristmasTag': ChristmasButtonComponent,
+   *   'CardContentType': {
+   *     default: DefaultCardComponent,
+   *     tags: { ChristmasTag: ChristmasCardComponent }
+   *   }
+   * });
+   * ```
+   *
+   * @example
+   * Using a dynamic resolver function:
+   *
+   * ```ts
+   * const registry = new ComponentRegistry((contentType, options) => {
+   *   if (contentType === 'Button') {
+   *     return options?.tag === 'primary' ? PrimaryButton : DefaultButton;
+   *   }
+   *   return undefined;
+   * });
+   * ```
    */
   constructor(resolverOrObject: ComponentResolverOrObject<T>) {
     this.resolver = resolverOrObject;
   }
 
   /** Returns the component given its content type name. Returns `undefined` if not found */
-  getComponent(contentType: string): T {
-    if (typeof this.resolver === 'object') {
-      return this.resolver[contentType];
-    } else {
-      return this.resolver(contentType);
+  getComponent(
+    contentType: string,
+    options: ResolverOptions = {}
+  ): T | undefined {
+    if (typeof this.resolver === 'function') {
+      return this.resolver(contentType, options);
     }
+
+    const entry = this.resolver[contentType];
+
+    if (!entry) {
+      return undefined;
+    }
+
+    if (!options.tag) {
+      return getDefaultComponent(entry);
+    }
+
+    // Search for the component `${contentType}:${tag}`
+    const taggedEntry = this.resolver[`${contentType}:${options.tag}`];
+
+    if (taggedEntry) {
+      return getDefaultComponent(taggedEntry);
+    }
+
+    return (
+      // Search for the component with the tag in the component definition
+      getTagComponent(entry, options.tag) ??
+      // Return the default component (without tag)
+      getDefaultComponent(entry)
+    );
   }
 }

--- a/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
@@ -44,7 +44,7 @@ type ComponentResolver<C> = (
 type ComponentMap<C> = Record<string, ComponentEntry<C>>;
 
 /** Returns true if `obj` is type {@linkcode ComponentWithVariants} */
-function hasVariants<T>(obj: unknown): obj is ComponentWithVariants<T> {
+function hasVariants(obj: unknown): obj is ComponentWithVariants<unknown> {
   return (
     typeof obj === 'object' && obj !== null && 'default' in obj && 'tags' in obj
   );

--- a/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
@@ -16,7 +16,9 @@ type ComponentWithVariants<C> = {
   /** Default component */
   default: C;
 
-  /** Tagged variants */
+  /**
+   * Tagged variants, where the keys are tag names and the values are the corresponding components.
+   */
   tags: Record<string, C>;
 };
 

--- a/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
@@ -83,39 +83,6 @@ export type ComponentResolverOrObject<C> =
 export class ComponentRegistry<T> {
   resolver: ComponentResolverOrObject<T>;
 
-  /**
-   * Creates a new ComponentRegistry instance.
-   *
-   * @param resolverOrObject - Either a ComponentResolver function for dynamic resolution,
-   *   or a ComponentMap object for static mappings between content types and components
-   *
-   * @example
-   * Using a static component map:
-   *
-   * ```ts
-   * const registry = new ComponentRegistry({
-   *   'ButtonContentType': ButtonComponent,
-   *   // You can define tags using the `ContentType:Tag` syntax:
-   *   'ButtonContentType:ChristmasTag': ChristmasButtonComponent,
-   *   'CardContentType': {
-   *     default: DefaultCardComponent,
-   *     tags: { ChristmasTag: ChristmasCardComponent }
-   *   }
-   * });
-   * ```
-   *
-   * @example
-   * Using a dynamic resolver function:
-   *
-   * ```ts
-   * const registry = new ComponentRegistry((contentType, options) => {
-   *   if (contentType === 'Button') {
-   *     return options?.tag === 'primary' ? PrimaryButton : DefaultButton;
-   *   }
-   *   return undefined;
-   * });
-   * ```
-   */
   constructor(resolverOrObject: ComponentResolverOrObject<T>) {
     this.resolver = resolverOrObject;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,37 @@ importers:
         specifier: workspace:*
         version: link:../../packages/optimizely-cms-sdk
 
+  __test__/test-website:
+    dependencies:
+      '@episerver/cms-cli':
+        specifier: workspace:*
+        version: link:../../packages/optimizely-cms-cli
+      '@episerver/cms-sdk':
+        specifier: workspace:*
+        version: link:../../packages/optimizely-cms-sdk
+      next:
+        specifier: 15.4.5
+        version: 15.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.17.28
+      '@types/react':
+        specifier: ^19
+        version: 19.0.12
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.0.4(@types/react@19.0.12)
+      typescript:
+        specifier: ^5
+        version: 5.8.3
+
   packages/optimizely-cms-cli:
     dependencies:
       '@babel/plugin-transform-react-jsx':
@@ -911,6 +942,9 @@ packages:
   '@next/env@15.4.3':
     resolution: {integrity: sha512-lKJ9KJAvaWzqurIsz6NWdQOLj96mdhuDMusLSYHw9HBe2On7BjUwU1WeRvq19x7NrEK3iOgMeSBV5qEhVH1cMw==}
 
+  '@next/env@15.4.5':
+    resolution: {integrity: sha512-ruM+q2SCOVCepUiERoxOmZY9ZVoecR3gcXNwCYZRvQQWRjhOiPJGmQ2fAiLR6YKWXcSAh7G79KEFxN3rwhs4LQ==}
+
   '@next/eslint-plugin-next@15.2.4':
     resolution: {integrity: sha512-O8ScvKtnxkp8kL9TpJTTKnMqlkZnS+QxwoQnJwPGBxjBbzd6OVVPEJ5/pMNrktSyXQD/chEfzfFzYLM6JANOOQ==}
 
@@ -929,6 +963,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@next/swc-darwin-arm64@15.4.5':
+    resolution: {integrity: sha512-84dAN4fkfdC7nX6udDLz9GzQlMUwEMKD7zsseXrl7FTeIItF8vpk1lhLEnsotiiDt+QFu3O1FVWnqwcRD2U3KA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@next/swc-darwin-x64@15.2.4':
     resolution: {integrity: sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==}
     engines: {node: '>= 10'}
@@ -937,6 +977,12 @@ packages:
 
   '@next/swc-darwin-x64@15.4.3':
     resolution: {integrity: sha512-ZPHRdd51xaxCMpT4viQ6h8TgYM1zPW1JIeksPY9wKlyvBVUQqrWqw8kEh1sa7/x0Ied+U7pYHkAkutrUwxbMcg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.4.5':
+    resolution: {integrity: sha512-CL6mfGsKuFSyQjx36p2ftwMNSb8PQog8y0HO/ONLdQqDql7x3aJb/wB+LA651r4we2pp/Ck+qoRVUeZZEvSurA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -953,6 +999,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@next/swc-linux-arm64-gnu@15.4.5':
+    resolution: {integrity: sha512-1hTVd9n6jpM/thnDc5kYHD1OjjWYpUJrJxY4DlEacT7L5SEOXIifIdTye6SQNNn8JDZrcN+n8AWOmeJ8u3KlvQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@next/swc-linux-arm64-musl@15.2.4':
     resolution: {integrity: sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==}
     engines: {node: '>= 10'}
@@ -961,6 +1013,12 @@ packages:
 
   '@next/swc-linux-arm64-musl@15.4.3':
     resolution: {integrity: sha512-HTL31NsmoafX+r5g91Yj3+q34nrn1xKmCWVuNA+fUWO4X0pr+n83uGzLyEOn0kUqbMZ40KmWx+4wsbMoUChkiQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@15.4.5':
+    resolution: {integrity: sha512-4W+D/nw3RpIwGrqpFi7greZ0hjrCaioGErI7XHgkcTeWdZd146NNu1s4HnaHonLeNTguKnL2Urqvj28UJj6Gqw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -977,6 +1035,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@next/swc-linux-x64-gnu@15.4.5':
+    resolution: {integrity: sha512-N6Mgdxe/Cn2K1yMHge6pclffkxzbSGOydXVKYOjYqQXZYjLCfN/CuFkaYDeDHY2VBwSHyM2fUjYBiQCIlxIKDA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@next/swc-linux-x64-musl@15.2.4':
     resolution: {integrity: sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==}
     engines: {node: '>= 10'}
@@ -985,6 +1049,12 @@ packages:
 
   '@next/swc-linux-x64-musl@15.4.3':
     resolution: {integrity: sha512-NyXUx6G7AayaRGUsVPenuwhyAoyxjQuQPaK50AXoaAHPwRuif4WmSrXUs8/Y0HJIZh8E/YXRm9H7uuGfiacpuQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@15.4.5':
+    resolution: {integrity: sha512-YZ3bNDrS8v5KiqgWE0xZQgtXgCTUacgFtnEgI4ccotAASwSvcMPDLua7BWLuTfucoRv6mPidXkITJLd8IdJplQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1001,6 +1071,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@next/swc-win32-arm64-msvc@15.4.5':
+    resolution: {integrity: sha512-9Wr4t9GkZmMNcTVvSloFtjzbH4vtT4a8+UHqDoVnxA5QyfWe6c5flTH1BIWPGNWSUlofc8dVJAE7j84FQgskvQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@15.2.4':
     resolution: {integrity: sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==}
     engines: {node: '>= 10'}
@@ -1009,6 +1085,12 @@ packages:
 
   '@next/swc-win32-x64-msvc@15.4.3':
     resolution: {integrity: sha512-i54YgUhvrUQxQD84SjAbkfWhYkOdm/DNRAVekCHLWxVg3aUbyC6NFQn9TwgCkX5QAS2pXCJo3kFboSFvrsd7dA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.4.5':
+    resolution: {integrity: sha512-voWk7XtGvlsP+w8VBz7lqp8Y+dYw/MTI4KeS0gTVtfdhdJ5QwhXLmNrndFOin/MDoCvUaLWMkYKATaCoUkt2/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3442,6 +3524,27 @@ packages:
       sass:
         optional: true
 
+  next@15.4.5:
+    resolution: {integrity: sha512-nJ4v+IO9CPmbmcvsPebIoX3Q+S7f6Fu08/dEWu0Ttfa+wVwQRh9epcmsyCPjmL2b8MxC+CkBR97jgDhUUztI3g==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -5283,7 +5386,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@lerna/create@8.2.2(encoding@0.1.13)(typescript@5.8.2)':
+  '@lerna/create@8.2.2(encoding@0.1.13)(typescript@5.8.3)':
     dependencies:
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
@@ -5301,7 +5404,7 @@ snapshots:
       console-control-strings: 1.1.0
       conventional-changelog-core: 5.0.1
       conventional-recommended-bump: 7.0.1
-      cosmiconfig: 9.0.0(typescript@5.8.2)
+      cosmiconfig: 9.0.0(typescript@5.8.3)
       dedent: 1.5.3
       execa: 5.0.0
       fs-extra: 11.3.0
@@ -5382,6 +5485,8 @@ snapshots:
 
   '@next/env@15.4.3': {}
 
+  '@next/env@15.4.5': {}
+
   '@next/eslint-plugin-next@15.2.4':
     dependencies:
       fast-glob: 3.3.1
@@ -5396,10 +5501,16 @@ snapshots:
   '@next/swc-darwin-arm64@15.4.3':
     optional: true
 
+  '@next/swc-darwin-arm64@15.4.5':
+    optional: true
+
   '@next/swc-darwin-x64@15.2.4':
     optional: true
 
   '@next/swc-darwin-x64@15.4.3':
+    optional: true
+
+  '@next/swc-darwin-x64@15.4.5':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.2.4':
@@ -5408,10 +5519,16 @@ snapshots:
   '@next/swc-linux-arm64-gnu@15.4.3':
     optional: true
 
+  '@next/swc-linux-arm64-gnu@15.4.5':
+    optional: true
+
   '@next/swc-linux-arm64-musl@15.2.4':
     optional: true
 
   '@next/swc-linux-arm64-musl@15.4.3':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.4.5':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.2.4':
@@ -5420,10 +5537,16 @@ snapshots:
   '@next/swc-linux-x64-gnu@15.4.3':
     optional: true
 
+  '@next/swc-linux-x64-gnu@15.4.5':
+    optional: true
+
   '@next/swc-linux-x64-musl@15.2.4':
     optional: true
 
   '@next/swc-linux-x64-musl@15.4.3':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.4.5':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.2.4':
@@ -5432,10 +5555,16 @@ snapshots:
   '@next/swc-win32-arm64-msvc@15.4.3':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@15.4.5':
+    optional: true
+
   '@next/swc-win32-x64-msvc@15.2.4':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.4.3':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.4.5':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6573,14 +6702,14 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig@9.0.0(typescript@5.8.2):
+  cosmiconfig@9.0.0(typescript@5.8.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.8.2
+      typescript: 5.8.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7850,7 +7979,7 @@ snapshots:
 
   lerna@8.2.2(encoding@0.1.13):
     dependencies:
-      '@lerna/create': 8.2.2(encoding@0.1.13)(typescript@5.8.2)
+      '@lerna/create': 8.2.2(encoding@0.1.13)(typescript@5.8.3)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
@@ -7868,7 +7997,7 @@ snapshots:
       conventional-changelog-angular: 7.0.0
       conventional-changelog-core: 5.0.1
       conventional-recommended-bump: 7.0.1
-      cosmiconfig: 9.0.0(typescript@5.8.2)
+      cosmiconfig: 9.0.0(typescript@5.8.3)
       dedent: 1.5.3
       envinfo: 7.13.0
       execa: 5.0.0
@@ -7920,7 +8049,7 @@ snapshots:
       strong-log-transformer: 2.1.0
       tar: 6.2.1
       temp-dir: 1.0.0
-      typescript: 5.8.2
+      typescript: 5.8.3
       upath: 2.0.1
       uuid: 10.0.0
       validate-npm-package-license: 3.0.4
@@ -8294,6 +8423,29 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.4.3
       '@next/swc-win32-arm64-msvc': 15.4.3
       '@next/swc-win32-x64-msvc': 15.4.3
+      sharp: 0.34.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@15.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@next/env': 15.4.5
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001707
+      postcss: 8.4.31
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      styled-jsx: 5.1.6(react@19.1.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.4.5
+      '@next/swc-darwin-x64': 15.4.5
+      '@next/swc-linux-arm64-gnu': 15.4.5
+      '@next/swc-linux-arm64-musl': 15.4.5
+      '@next/swc-linux-x64-gnu': 15.4.5
+      '@next/swc-linux-x64-musl': 15.4.5
+      '@next/swc-win32-arm64-msvc': 15.4.5
+      '@next/swc-win32-x64-msvc': 15.4.5
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
This pull request

- enhancements to the SDK's component registry, and updates to the display template handling. 
- introduces a new test website built with Next.js to validate SDK and CLI features against a CMS.

### SDK Enhancements
* Updated the `ComponentRegistry` in `packages/optimizely-cms-sdk` to support both static component maps and dynamic resolver functions. Introduced support for tagged variants in component resolution.
* Enhanced the `initReactComponentRegistry` function and `OptimizelyComponent` to handle display template tags and provide improved flexibility for component mapping.