### PR TITLE
Export and use GraphErrors

### DIFF
--- a/packages/optimizely-cms-sdk/src/index.ts
+++ b/packages/optimizely-cms-sdk/src/index.ts
@@ -16,6 +16,7 @@ export {
   BlankExperienceContentType,
 } from './model/internalContentTypes.js';
 
+export * as GraphErrors from './graph/error.js';
 export * as ContentTypes from './model/contentTypes.js';
 export * as DisplayTemplates from './model/displayTemplates.js';
 export * as Properties from './model/properties.js';


### PR DESCRIPTION
This PR exports all custom-defined `GraphErrors` and implements an error handler in the sample site with them