### PR TITLE
Fetch with variation option

### DIFF
--- a/__test__/test-website/src/app/[...slug]/page.tsx
+++ b/__test__/test-website/src/app/[...slug]/page.tsx
@@ -1,4 +1,4 @@
-import { GraphClient } from '@episerver/cms-sdk';
+import { GraphClient, GraphErrors } from '@episerver/cms-sdk';
 import { OptimizelyComponent } from '@episerver/cms-sdk/react/server';
 import React from 'react';
 
@@ -6,15 +6,36 @@ type Props = {
   params: Promise<{
     slug: string[];
   }>;
+  // Assume that search params are correct:
+  searchParams: Promise<{ variation?: string }>;
 };
 
-export default async function Page({ params }: Props) {
+function handleGraphErrors(err: unknown): never {
+  if (err instanceof GraphErrors.GraphResponseError) {
+    console.log('Error message:', err.message);
+    console.log('Query:', err.request.query);
+    console.log('Variables:', err.request.variables);
+  }
+  if (err instanceof GraphErrors.GraphContentResponseError) {
+    console.log('Detailed errors: ', err.errors);
+  }
+
+  throw err;
+}
+
+export default async function Page({ params, searchParams }: Props) {
   const { slug } = await params;
+  const { variation } = await searchParams;
 
   const client = new GraphClient(process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!, {
     graphUrl: process.env.OPTIMIZELY_GRAPH_URL,
   });
-  const c = await client.fetchContent(`/${slug.join('/')}/`);
 
-  return <OptimizelyComponent opti={c} />;
+  const path = `/${slug.join('/')}/`;
+
+  const content = variation
+    ? await client.fetchContent({ path, variation }).catch(handleGraphErrors)
+    : await client.fetchContent(path).catch(handleGraphErrors);
+
+  return <OptimizelyComponent opti={content} />;
 }

--- a/__test__/test-website/src/app/[...slug]/page.tsx
+++ b/__test__/test-website/src/app/[...slug]/page.tsx
@@ -31,11 +31,9 @@ export default async function Page({ params, searchParams }: Props) {
     graphUrl: process.env.OPTIMIZELY_GRAPH_URL,
   });
 
-  const path = `/${slug.join('/')}/`;
-
-  const content = variation
-    ? await client.fetchContent({ path, variation }).catch(handleGraphErrors)
-    : await client.fetchContent(path).catch(handleGraphErrors);
+  const content = await client
+    .fetchContent({ path: `/${slug.join('/')}/`, variation })
+    .catch(handleGraphErrors);
 
   return <OptimizelyComponent opti={content} />;
 }

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -252,8 +252,8 @@ export function createQuery(contentType: string) {
 
   return `
 ${fragment.join('\n')}
-query FetchContent($filter: _ContentWhereInput) {
-  _Content(where: $filter) {
+query FetchContent($where: _ContentWhereInput, $variation: VariationInput) {
+  _Content(where: $where, variation: $variation) {
     item {
       __typename
       ...${contentType}

--- a/packages/optimizely-cms-sdk/src/graph/error.ts
+++ b/packages/optimizely-cms-sdk/src/graph/error.ts
@@ -1,4 +1,4 @@
-import type { GraphVariables } from './index.js';
+import type { ContentInput } from './filters.js';
 
 /** Represents the request sent to graph */
 type GraphRequest = {
@@ -6,7 +6,7 @@ type GraphRequest = {
   query: string;
 
   /** Variables sent to Graph */
-  variables: GraphVariables;
+  variables: ContentInput;
 };
 
 /** Super-class for all errors related to Optimizely Graph */

--- a/packages/optimizely-cms-sdk/src/graph/filters.ts
+++ b/packages/optimizely-cms-sdk/src/graph/filters.ts
@@ -2,6 +2,8 @@
  * This module contains the TypeScript definitions of a Graph Query
  * and functions to build those filters based on path,
  * preview parameters, etc.
+ *
+ * This is used internally in the SDK
  */
 
 /**

--- a/packages/optimizely-cms-sdk/src/graph/filters.ts
+++ b/packages/optimizely-cms-sdk/src/graph/filters.ts
@@ -1,0 +1,178 @@
+/**
+ * This module contains the TypeScript definitions of a Graph Query
+ * and functions to build those filters based on path,
+ * preview parameters, etc.
+ */
+
+/**
+ * Creates a {@linkcode ContentInput} object that filters results by a specific URL path.
+ *
+ * @param path - The URL path to filter by.
+ * @returns A `GraphQueryArguments` object with a `where` clause that matches the given path.
+ */
+export function pathFilter(path: string): ContentInput {
+  return {
+    where: {
+      _metadata: {
+        url: {
+          default: {
+            eq: path,
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Creates a {@linkcode ContentInput} object for previewing content based on key, version, and locale.
+ *
+ * @param params - An object containing the following properties:
+ * @param params.key - The unique key identifying the content.
+ * @param params.ver - The version of the content to preview.
+ * @param params.loc - The locale of the content to preview.
+ *
+ * @returns A `GraphQueryArguments` object with a `where` clause filtering by key, version, and locale.
+ */
+export function previewFilter(params: {
+  key: string;
+  ver: string;
+  loc: string;
+}): ContentInput {
+  return {
+    where: {
+      _metadata: {
+        key: { eq: params.key },
+        version: { eq: params.ver },
+        locale: { eq: params.loc },
+      },
+    },
+  };
+}
+
+export function variationsFilter(
+  values?: string | (string | undefined | null)[],
+  includeOriginal?: boolean
+): ContentInput {
+  if (!values) {
+    return {
+      variation: {
+        include: 'ALL',
+      },
+    };
+  }
+
+  if (typeof values === 'string') {
+    return {
+      variation: {
+        include: 'SOME',
+        value: [values],
+        includeOriginal: includeOriginal ?? true,
+      },
+    };
+  }
+
+  const notNulls = values.filter((v) => typeof v === 'string');
+
+  return {
+    variation: {
+      include: 'SOME',
+      value: notNulls,
+      includeOriginal: notNulls.length !== values.length,
+    },
+  };
+}
+
+/**
+ * Arguments for querying content via the Graph API.
+ */
+export type ContentInput = {
+  variation?: VariationInput;
+  where?: ContentWhereInput;
+};
+
+type VariationInput = {
+  include?: VariationIncludeMode;
+  value?: string[];
+  includeOriginal?: boolean;
+};
+
+type VariationIncludeMode = 'ALL' | 'SOME' | 'NONE';
+
+type ContentWhereInput = {
+  _and?: ContentWhereInput[];
+  _or?: ContentWhereInput[];
+  _fulltext?: StringFilterInput;
+  _modified?: DateFilterInput;
+  _metadata?: IContentMetadataWhereInput;
+};
+
+type StringFilterInput = ScalarFilterInput<string> & {
+  like?: string;
+  startsWith?: string;
+  endsWith?: string;
+  in?: string[];
+  notIn?: string[];
+  match?: string;
+  contains?: string;
+  synonyms?: ('ONE' | 'TWO')[];
+  fuzzly?: boolean;
+};
+
+type DateFilterInput = ScalarFilterInput<string> & {
+  gt?: string;
+  gte?: string;
+  lt?: string;
+  lte?: string;
+  decay?: {
+    origin?: string;
+    scale?: number;
+    rate?: number;
+  };
+};
+
+type IContentMetadataWhereInput = {
+  key?: StringFilterInput;
+  locale?: StringFilterInput;
+  fallbackForLocale?: StringFilterInput;
+  version?: StringFilterInput;
+  displayName?: StringFilterInput;
+  url?: ContentUrlInput<StringFilterInput>;
+  types?: StringFilterInput;
+  published?: DateFilterInput;
+  status?: StringFilterInput;
+  changeset?: StringFilterInput;
+  created?: DateFilterInput;
+  lastModified?: DateFilterInput;
+  sortOrder?: IntFilterInput;
+  variation?: StringFilterInput;
+};
+
+type IntFilterInput = ScalarFilterInput<number> & {
+  gt?: number;
+  gte?: number;
+  lt?: number;
+  lte?: number;
+  in?: number[];
+  notIn?: number[];
+  factor?: {
+    value?: number;
+    modifier?: 'NONE' | 'SQUARE' | 'SQRT' | 'LOG' | 'RECIPROCAL';
+  };
+};
+
+type ContentUrlInput<T> = {
+  type?: T;
+  default?: T;
+  hierarchical?: T;
+  internal?: T;
+  graph?: T;
+  base?: T;
+};
+
+type ScalarFilterInput<T> = {
+  eq?: T;
+  notEq?: T;
+  exist?: boolean;
+  boost?: number;
+};

--- a/packages/optimizely-cms-sdk/src/graph/filters.ts
+++ b/packages/optimizely-cms-sdk/src/graph/filters.ts
@@ -52,35 +52,11 @@ export function previewFilter(params: {
   };
 }
 
-export function variationsFilter(
-  values?: string | (string | undefined | null)[],
-  includeOriginal?: boolean
-): ContentInput {
-  if (!values) {
-    return {
-      variation: {
-        include: 'ALL',
-      },
-    };
-  }
-
-  if (typeof values === 'string') {
-    return {
-      variation: {
-        include: 'SOME',
-        value: [values],
-        includeOriginal: includeOriginal ?? true,
-      },
-    };
-  }
-
-  const notNulls = values.filter((v) => typeof v === 'string');
-
+export function variationFilter(value: string): ContentInput {
   return {
     variation: {
       include: 'SOME',
-      value: notNulls,
-      includeOriginal: notNulls.length !== values.length,
+      value: [value],
     },
   };
 }

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -26,12 +26,10 @@ export type PreviewParams = {
 };
 
 /** Arguments for the method `fetchContent` */
-type PathOrOptions =
-  | string
-  | {
-      path: string;
-      variation: string;
-    };
+type FetchContentOptions = {
+  path: string;
+  variation: string;
+};
 
 const FETCH_CONTENT_TYPE_QUERY = `
 query FetchContentType($where: _ContentWhereInput, $variation: VariationInput) {
@@ -128,7 +126,13 @@ export class GraphClient {
     return json.data;
   }
 
-  /** Fetches the content type of a content. Returns `undefined` if the content doesn't exist */
+  /**
+   * Fetches the content type metadata for a given content input.
+   *
+   * @param input - The content input used to query the content type.
+   * @param previewToken - Optional preview token for fetching preview content.
+   * @returns A promise that resolves to the first content type metadata object, or `undefined` if not found.
+   */
   private async fetchContentType(input: ContentInput, previewToken?: string) {
     const data = await this.request(
       FETCH_CONTENT_TYPE_QUERY,
@@ -139,8 +143,18 @@ export class GraphClient {
     return data._Content?.item?._metadata?.types?.[0];
   }
 
-  /** Fetches a content given its path */
-  async fetchContent(options: PathOrOptions) {
+  /**
+   * Fetches content from the CMS based on the provided path or options.
+   *
+   * If a string is provided, it is treated as a content path. If an object is provided,
+   * it may include both a path and a variation to filter the content.
+   *
+   * @param options - A string representing the content path,
+   *   or an {@linkcode FetchContentOptions} containing path and variation filters.
+   *
+   * @returns A promise that resolves to the fetched content item.
+   */
+  async fetchContent(options: string | FetchContentOptions) {
     let input: ContentInput;
 
     if (typeof options === 'string') {

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -8,7 +8,7 @@ import {
   ContentInput as GraphVariables,
   pathFilter,
   previewFilter,
-  variationsFilter,
+  variationFilter,
 } from './filters.js';
 
 /** Options for Graph */
@@ -50,7 +50,7 @@ function buildGraphVariables(
 
   return {
     ...(options.path && pathFilter(options.path)),
-    ...(options.variation && variationsFilter(options.variation)),
+    ...(options.variation && variationFilter(options.variation)),
   };
 }
 

--- a/packages/optimizely-cms-sdk/src/index.ts
+++ b/packages/optimizely-cms-sdk/src/index.ts
@@ -8,7 +8,7 @@ export {
   initContentTypeRegistry,
   initDisplayTemplateRegistry,
 } from './model/index.js';
-export { GraphClient, getFilterFromPath } from './graph/index.js';
+export { GraphClient } from './graph/index.js';
 export { createQuery } from './graph/createQuery.js';
 export type { PreviewParams } from './graph/index.js';
 export {

--- a/samples/nextjs-template/src/app/json/[...slug]/page.tsx
+++ b/samples/nextjs-template/src/app/json/[...slug]/page.tsx
@@ -1,8 +1,4 @@
-import {
-  getFilterFromPath,
-  GraphClient,
-  GraphErrors,
-} from '@episerver/cms-sdk';
+import { GraphClient, GraphErrors } from '@episerver/cms-sdk';
 import { createQuery } from '@episerver/cms-sdk';
 
 type Props = {
@@ -36,7 +32,7 @@ export default async function Page({ params }: Props) {
   // Note: this is shown for demo purposes.
   // `fetchContentType` and `createQuery` are not needed
   const contentType = await client
-    .fetchContentType(getFilterFromPath(path))
+    .fetchContentType(path)
     .catch(handleGraphErrors);
   const query = createQuery(contentType);
   const response = await client.fetchContent(path).catch(handleGraphErrors);


### PR DESCRIPTION
This PR expands the `GraphClient.fetchContent` method to allow path and variation as filter.

As a refactor, introduces a new internal `filters.ts` module with type definitions and utility functions (`pathFilter`, `previewFilter`, `variationsFilter`) for building GraphQL query filters, including support for variations and preview parameters.