### PR TITLE
Display template tags in experience

### DIFF
--- a/__test__/test-website/src/app/layout.tsx
+++ b/__test__/test-website/src/app/layout.tsx
@@ -12,6 +12,7 @@ import {
   ct3,
   dt1,
   dt2,
+  dt3,
 } from '@/components/with-display-templates';
 import {
   initContentTypeRegistry,
@@ -20,7 +21,7 @@ import {
 import { initReactComponentRegistry } from '@episerver/cms-sdk/react/server';
 
 initContentTypeRegistry([ct1, ct2, ct3]);
-initDisplayTemplateRegistry([dt1, dt2]);
+initDisplayTemplateRegistry([dt1, dt2, dt3]);
 initReactComponentRegistry({
   resolver: {
     test_c1: {

--- a/__test__/test-website/src/app/layout.tsx
+++ b/__test__/test-website/src/app/layout.tsx
@@ -6,6 +6,7 @@ import {
   Component2,
   Component2A,
   Component3,
+  Component3C,
   ct1,
   ct2,
   ct3,
@@ -31,7 +32,12 @@ initReactComponentRegistry({
     },
     test_c2: Component2,
     'test_c2:tagA': Component2A,
-    test_c3: Component3,
+    test_c3: {
+      default: Component3,
+      tags: {
+        tagC: Component3C,
+      },
+    },
     BlankSection: BlankSection,
   },
 });

--- a/__test__/test-website/src/components/with-display-templates.tsx
+++ b/__test__/test-website/src/components/with-display-templates.tsx
@@ -51,6 +51,15 @@ export const dt2 = displayTemplate({
   tag: 'tagB',
 });
 
+export const dt3 = displayTemplate({
+  key: 'test_dt3',
+  baseType: '_experience',
+  displayName: 'test dt3',
+  isDefault: false,
+  settings: {},
+  tag: 'tagC',
+});
+
 type Props1 = { opti: Infer<typeof ct1> };
 type Props2 = { opti: Infer<typeof ct2> };
 type Props3 = { opti: Infer<typeof ct3> };
@@ -82,7 +91,16 @@ export function Component2A({ opti }: Props2) {
 export function Component3({ opti }: Props3) {
   return (
     <div>
-      <h1>This is an experience</h1>
+      <h1>This is an experience (Component3)</h1>
+      <OptimizelyExperience nodes={opti.composition.nodes ?? []} />
+    </div>
+  );
+}
+
+export function Component3C({ opti }: Props3) {
+  return (
+    <div>
+      <h1>This is an experience (Component3C)</h1>
       <OptimizelyExperience nodes={opti.composition.nodes ?? []} />
     </div>
   );

--- a/packages/optimizely-cms-sdk/src/infer.ts
+++ b/packages/optimizely-cms-sdk/src/infer.ts
@@ -95,8 +95,8 @@ export type ExperienceCompositionNode = {
 
   key: string;
   displayName: string;
-  displayTemplateKey: string;
-  displaySettings: DisplaySettingsType[];
+  displayTemplateKey: string | null;
+  displaySettings: DisplaySettingsType[] | null;
 };
 
 export type ExperienceStructureNode = ExperienceCompositionNode & {

--- a/packages/optimizely-cms-sdk/src/model/displayTemplateRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/model/displayTemplateRegistry.ts
@@ -18,8 +18,10 @@ export function getDisplayTemplate(name: string) {
  *
  * @param key DisplayTemplate's key
  */
-export function getDisplayTemplateTag(key: string): string | undefined {
-  return getDisplayTemplate(key)?.tag;
+export function getDisplayTemplateTag(key?: string | null): string | undefined {
+  if (key) {
+    return getDisplayTemplate(key)?.tag;
+  }
 }
 
 /** Get all the DisplayTemplates */

--- a/packages/optimizely-cms-sdk/src/model/displayTemplates.ts
+++ b/packages/optimizely-cms-sdk/src/model/displayTemplates.ts
@@ -63,7 +63,7 @@ export type DisplayTemplate<T = DisplayTemplateVariant> = T & {
 };
 
 export function parseDisplaySettings(
-  displaySettings?: DisplaySettingsType[]
+  displaySettings?: DisplaySettingsType[] | null
 ): Record<string, string> | undefined {
   if (!displaySettings) {
     return undefined; // Return undefined if displaySettings is not provided

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -9,6 +9,7 @@ import {
   ExperienceNode,
   ExperienceComponentNode,
   DisplaySettingsType,
+  ExperienceCompositionNode,
 } from '../infer.js';
 import { isComponentNode } from '../util/baseTypeUtil.js';
 import { parseDisplaySettings } from '../model/displayTemplates.js';
@@ -80,6 +81,8 @@ type OptimizelyComponentProps = {
 
     /** Preview context */
     __context?: { edit: boolean; preview_token: string };
+
+    composition?: ExperienceCompositionNode;
   };
 
   displaySettings?: Record<string, string>;
@@ -95,7 +98,8 @@ export async function OptimizelyComponent({
   }
 
   const Component = await componentRegistry.getComponent(opti.__typename, {
-    tag: opti.__tag,
+    tag:
+      opti.__tag ?? getDisplayTemplateTag(opti.composition?.displayTemplateKey),
   });
 
   if (!Component) {


### PR DESCRIPTION
This PR fixes a bug where DisplayTemplateTag applied to Experience (in the top-level) are ignored. It also updates the test-website