### PR TITLE
Allow `string` in `mayContainTypes` and handle validations in CLI

### DIFF
--- a/packages/optimizely-cms-cli/src/mapper/contentToPackage.ts
+++ b/packages/optimizely-cms-cli/src/mapper/contentToPackage.ts
@@ -9,13 +9,17 @@ import {
  * Transforms a content type object to a manifest format.
  * Validates the content type key and formats its properties.
  * @param contentType - The content type object to transform.
+ * @param allowedKeys - Set of valid content type keys for validation.
  * @returns
  */
-function transformContentType(contentType: AnyContentType): any {
+function transformContentType(
+  contentType: AnyContentType,
+  allowedKeys?: Set<string>
+): any {
   validateContentTypeKey(contentType.key);
 
   const { properties = {} } = contentType;
-  const parsedContentType = parseChildContentType(contentType);
+  const parsedContentType = parseChildContentType(contentType, allowedKeys);
   const formattedProperties = transformProperties(properties);
 
   return {
@@ -26,9 +30,11 @@ function transformContentType(contentType: AnyContentType): any {
 
 /**
  * Maps an array of content types to a manifest format.
+ * Validates string entries in mayContainTypes against known content type keys.
  * @param contentTypes - Array of content types to transform.
  * @returns An array of transformed content types.
  */
 export function mapContentToManifest(contentTypes: AnyContentType[]): any[] {
-  return contentTypes.map(transformContentType);
+  const allowedKeys = new Set(contentTypes.map((ct) => ct.key));
+  return contentTypes.map((ct) => transformContentType(ct, allowedKeys));
 }

--- a/packages/optimizely-cms-cli/src/tests/parseChildContentType.test.ts
+++ b/packages/optimizely-cms-cli/src/tests/parseChildContentType.test.ts
@@ -46,3 +46,29 @@ describe('parseChildContentType', () => {
     `);
   });
 });
+
+describe('parseChildContentType errors', () => {
+  it('throws on duplicate entries in mayContainTypes', () => {
+    const contentType = {
+      key: 'Blog',
+      mayContainTypes: ['Article', 'Article', 'Gallery'],
+    };
+    const allowedKeys = new Set(['Article', 'Gallery']);
+
+    expect(() => parseChildContentType(contentType, allowedKeys)).toThrow(
+      '❌ [optimizely-cms-cli] Duplicate entries in mayContainTypes for content type "Blog": Article'
+    );
+  });
+
+  it('throws on unknown entries, underscore keys allowed', () => {
+    const contentType = {
+      key: 'Blog',
+      mayContainTypes: ['_page', 'Valid', 'Unknown'],
+    };
+    const allowedKeys = new Set(['Valid']);
+
+    expect(() => parseChildContentType(contentType, allowedKeys)).toThrow(
+      '❌ [optimizely-cms-cli] Invalid mayContainTypes for content type "Blog". Unknown content types: Unknown'
+    );
+  });
+});

--- a/packages/optimizely-cms-sdk/src/model/contentTypes.ts
+++ b/packages/optimizely-cms-sdk/src/model/contentTypes.ts
@@ -35,7 +35,8 @@ type BaseContentType = {
 export type PageContentType = BaseContentType & {
   baseType: '_page';
   mayContainTypes?: Array<
-    ContentType<PageContentType | ExperienceContentType | FolderContentType>
+    | ContentType<PageContentType | ExperienceContentType | FolderContentType>
+    | string
   >;
 };
 
@@ -43,21 +44,22 @@ export type PageContentType = BaseContentType & {
 export type ExperienceContentType = BaseContentType & {
   baseType: '_experience';
   mayContainTypes?: Array<
-    ContentType<PageContentType | ExperienceContentType | FolderContentType>
+    | ContentType<PageContentType | ExperienceContentType | FolderContentType>
+    | string
   >;
 };
 
 /** Represents the Folder (Used in the asset panel to organizing content and not in Graph) type in CMS */
 export type FolderContentType = BaseContentType & {
   baseType: '_folder';
-  mayContainTypes?: Array<ContentType<AnyContentType>>;
+  mayContainTypes?: Array<ContentType<AnyContentType> | string>;
 };
 
 /** Represents the "Component" type (also called "Block") in CMS */
 export type ComponentContentType = BaseContentType & {
   baseType: '_component';
   compositionBehaviors?: ('sectionEnabled' | 'elementEnabled')[];
-  mayContainTypes?: Array<ContentType<ComponentContentType>>;
+  mayContainTypes?: Array<ContentType<ComponentContentType> | string>;
 };
 
 /** This content type is used only internally */


### PR DESCRIPTION
- Allow strings (ContentType keys) to be passed to `mayContainTypes`.
- Enhance content type validation by adding allowedKeys (all contenTypes) from CLI.
- Handling duplicates in mayContainTypes from CLI.

Note: This will help us to mitigate the self reference errors and circular reference errors.