### PR TITLE
Small bugfixes (variations)

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -261,6 +261,9 @@ query GetContent($where: _ContentWhereInput, $variation: VariationInput) {
     item {
       __typename
       ...${contentType}
+      _metadata {
+        variation
+      }
     }
   }
 }

--- a/packages/optimizely-cms-sdk/src/graph/filters.ts
+++ b/packages/optimizely-cms-sdk/src/graph/filters.ts
@@ -74,7 +74,7 @@ export type ContentInput = {
 };
 
 export type VariationInput =
-  | { include: 'NONE' }
+  | { include: 'NONE'; includeOriginal?: boolean }
   | { include: 'ALL'; includeOriginal?: boolean }
   | {
       include: 'SOME';

--- a/packages/optimizely-cms-sdk/src/graph/filters.ts
+++ b/packages/optimizely-cms-sdk/src/graph/filters.ts
@@ -69,11 +69,11 @@ export function variationFilter(value: string): ContentInput {
  * Arguments for querying content via the Graph API.
  */
 export type ContentInput = {
-  variation?: VariationInput;
+  variation?: GraphVariationInput;
   where?: ContentWhereInput;
 };
 
-export type VariationInput =
+export type GraphVariationInput =
   | { include: 'NONE'; includeOriginal?: boolean }
   | { include: 'ALL'; includeOriginal?: boolean }
   | {

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -12,7 +12,7 @@ import {
   ContentInput as GraphVariables,
   pathFilter,
   previewFilter,
-  VariationInput,
+  GraphVariationInput,
 } from './filters.js';
 
 /** Options for Graph */
@@ -29,9 +29,11 @@ export type PreviewParams = {
   loc: string;
 };
 
-type FetchContentOptions = {
-  variation?: VariationInput;
+export type GraphGetContentOptions = {
+  variation?: GraphVariationInput;
 };
+
+export { GraphVariationInput };
 
 const GET_CONTENT_METADATA_QUERY = `
 query GetContentMetadata($where: _ContentWhereInput, $variation: VariationInput) {
@@ -187,7 +189,10 @@ export class GraphClient {
    *
    * @returns An iterator that traverses all found items
    */
-  async getContentByPath<T = any>(path: string, options?: FetchContentOptions) {
+  async getContentByPath<T = any>(
+    path: string,
+    options?: GraphGetContentOptions
+  ) {
     const input: GraphVariables = {
       ...pathFilter(path),
       variation: options?.variation,

--- a/packages/optimizely-cms-sdk/src/index.ts
+++ b/packages/optimizely-cms-sdk/src/index.ts
@@ -13,7 +13,6 @@ export {
   GraphGetContentOptions,
   GraphVariationInput,
 } from './graph/index.js';
-export { createSingleContentQuery } from './graph/createQuery.js';
 export type { PreviewParams } from './graph/index.js';
 export {
   BlankSectionContentType,

--- a/packages/optimizely-cms-sdk/src/index.ts
+++ b/packages/optimizely-cms-sdk/src/index.ts
@@ -8,7 +8,11 @@ export {
   initContentTypeRegistry,
   initDisplayTemplateRegistry,
 } from './model/index.js';
-export { GraphClient } from './graph/index.js';
+export {
+  GraphClient,
+  GraphGetContentOptions,
+  GraphVariationInput,
+} from './graph/index.js';
 export { createSingleContentQuery } from './graph/createQuery.js';
 export type { PreviewParams } from './graph/index.js';
 export {


### PR DESCRIPTION
This PR includes small bugfixes and improvements:

- TypeScript types `GraphGetContentOptions` and `GraphVariationInput` are public
- Function `createSingleContentQuery` is no longer public