### PR TITLE
Return empty array if not found instead of throwing error

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -152,12 +152,7 @@ export class GraphClient {
     const type = data._Content?.item?._metadata?.types?.[0];
 
     if (!type) {
-      throw new GraphResponseError('No content found', {
-        request: {
-          query: GET_CONTENT_METADATA_QUERY,
-          variables: input,
-        },
-      });
+      return null;
     }
 
     if (typeof type !== 'string') {
@@ -187,7 +182,7 @@ export class GraphClient {
    * @param contentType - A string representing the content type. If omitted, the method
    *   will try to get the content type name from the CMS.
    *
-   * @returns An iterator that traverses all found items
+   * @returns An array of all items matching the path and options
    */
   async getContentByPath<T = any>(
     path: string,
@@ -198,6 +193,11 @@ export class GraphClient {
       variation: options?.variation,
     };
     const contentTypeName = await this.getContentType(input);
+
+    if (!contentTypeName) {
+      return [];
+    }
+
     const query = createMultipleContentQuery(contentTypeName);
     const response = (await this.request(query, input)) as ItemsResponse<T>;
 

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -182,7 +182,7 @@ export class GraphClient {
    * @param contentType - A string representing the content type. If omitted, the method
    *   will try to get the content type name from the CMS.
    *
-   * @returns An array of all items matching the path and options
+   * @returns An array of all items matching the path and options. Returns an empty array if no content is found.
    */
   async getContentByPath<T = any>(
     path: string,

--- a/samples/nextjs-template/src/app/[...slug]/page.tsx
+++ b/samples/nextjs-template/src/app/[...slug]/page.tsx
@@ -1,5 +1,6 @@
 import { GraphClient } from '@episerver/cms-sdk';
 import { OptimizelyComponent } from '@episerver/cms-sdk/react/server';
+import { notFound } from 'next/navigation';
 import React from 'react';
 
 type Props = {
@@ -15,6 +16,10 @@ export default async function Page({ params }: Props) {
     graphUrl: process.env.OPTIMIZELY_GRAPH_URL,
   });
   const c = await client.getContentByPath(`/${slug.join('/')}/`);
+
+  if (c.length === 0) {
+    notFound();
+  }
 
   return <OptimizelyComponent opti={c[0]} />;
 }


### PR DESCRIPTION
This PR changes the behavior of `getContentByPath`. Previously throwed an `Error` when content was not found. Now it returns an empty array instead.

Note: this PR doesn't change the `getPreviewContent` function, which might be addressed in the future.