### PR TITLE
CMS-45869 Add 'span' and 'mark' to GenericElementType and update fallback logic in ReactRichTextRenderer

### DIFF
--- a/packages/optimizely-cms-sdk/src/components/richText/renderer.ts
+++ b/packages/optimizely-cms-sdk/src/components/richText/renderer.ts
@@ -476,6 +476,8 @@ export const defaultElementTypeMap: Record<
   link: { tag: 'a' },
   image: { tag: 'img', config: { selfClosing: true } },
   br: { tag: 'br', config: { selfClosing: true } },
+  span: { tag: 'span' },
+  mark: { tag: 'mark' },
 
   // Table
   table: { tag: 'table' },
@@ -486,7 +488,6 @@ export const defaultElementTypeMap: Record<
 
   // Root wrapper
   richText: { tag: 'div', config: { className: 'cms:rich-text' } },
-  mark: { tag: 'mark' },
   sup: { tag: 'sup' },
   sub: { tag: 'sub' },
   ins: { tag: 'ins' },

--- a/packages/optimizely-cms-sdk/src/react/richText/renderer.ts
+++ b/packages/optimizely-cms-sdk/src/react/richText/renderer.ts
@@ -151,7 +151,21 @@ export class ReactRichTextRenderer extends BaseRichTextRenderer<
    * Get default element component for unknown types
    */
   private getDefaultElement(elementType: string): ElementRenderer {
-    const fallbackTag = this.getConfig('elementFallback', 'div') as string;
+    // Use span as fallback for inline elements to avoid hydration errors with block elements in paragraphs
+    const inlineElements = [
+      'span',
+      'mark',
+      'strong',
+      'em',
+      'u',
+      's',
+      'code',
+      'i',
+      'b',
+    ];
+    const fallbackTag = inlineElements.includes(elementType)
+      ? 'span'
+      : (this.getConfig('elementFallback', 'div') as string);
 
     return ({ children }) => {
       return React.createElement(fallbackTag, {}, children);


### PR DESCRIPTION
- Update `getDefaultElement` to use `inlineElements` to render inner elements.