### PR TITLE
Handle URL paths with and without trailing slashes

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/filters.ts
+++ b/packages/optimizely-cms-sdk/src/graph/filters.ts
@@ -6,6 +6,21 @@
  * This is used internally in the SDK
  */
 
+/** Returns two versions of the same path. One with trailing slash and one without it */
+function normalizePath(path: string) {
+  if (path.endsWith('/')) {
+    return {
+      pathWithTrailingSlash: path,
+      pathWithoutTrailingSlash: path.slice(0, -1),
+    };
+  } else {
+    return {
+      pathWithTrailingSlash: path + '/',
+      pathWithoutTrailingSlash: path,
+    };
+  }
+}
+
 /**
  * Creates a {@linkcode ContentInput} object that filters results by a specific URL path.
  *
@@ -13,16 +28,29 @@
  * @returns A `GraphQueryArguments` object with a `where` clause that matches the given path.
  */
 export function pathFilter(path: string, host?: string): ContentInput {
+  const { pathWithTrailingSlash, pathWithoutTrailingSlash } =
+    normalizePath(path);
+
   return {
     where: {
-      _metadata: {
-        url: {
-          default: {
-            eq: path,
+      _or: [
+        {
+          _metadata: {
+            url: {
+              default: { eq: pathWithTrailingSlash },
+              base: host ? { eq: host } : undefined,
+            },
           },
-          base: host ? { eq: host } : undefined,
         },
-      },
+        {
+          _metadata: {
+            url: {
+              default: { eq: pathWithoutTrailingSlash },
+              base: host ? { eq: host } : undefined,
+            },
+          },
+        },
+      ],
     },
   };
 }


### PR DESCRIPTION
This PR changes the way URLs are queried in graph.

Now, paths ending with and without trailing slash are considered identical. The SDK will try to search for both versions.