### PR TITLE
Use Graph to determine DAM availability based on `cmp_Asset` type

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -52,7 +52,7 @@ query GetContentMetadata($where: _ContentWhereInput, $variation: VariationInput)
       }
     }
   }
-  # Check if "cmp asset" type exists which indicates that DAM is enabled
+  # Check if "cmp_Asset" type exists which indicates that DAM is enabled
   damAssetType: __type(name: "cmp_Asset") {
     __typename
   }


### PR DESCRIPTION
### This PR to check if we can use meta data query to check if we have `cmp_Asset` available in graph. Which should indicate that CMP DAM is enabled in a particular instance. 

- This simplifies the steps developers have to do when using dam assets in the sdk. With this methods we dont have to pass the attribute `damEnabled` to the `GraphClient`.

```
  const client = new GraphClient(process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!, {
    graphUrl: process.env.OPTIMIZELY_GRAPH_GATEWAY,
    damEnabled: true // not needed since we know if DAM is enabled from the meta data call just before we generate fragments
  });
```