### PR TITLE
Circular error when push manifest from alloy to cms

### DIFF
--- a/templates/alloy-template/src/components/Standard.tsx
+++ b/templates/alloy-template/src/components/Standard.tsx
@@ -11,7 +11,7 @@ export const StandardContentType = contentType({
   key: 'Standard',
   displayName: 'Standard Page',
   baseType: '_experience',
-  mayContainTypes: ['*'], // Passed 'News' as a string to avoid circular dependency
+  mayContainTypes: ['*'],
   properties: {
     image: {
       type: 'contentReference',


### PR DESCRIPTION
I think this one is just a temporary solution, we should fix it in the integration API instead of.
Bug: CMS-49000