### PR TITLE
Add preview_token to rich text images

### DIFF
--- a/docs/10-richtext-component-react.md
+++ b/docs/10-richtext-component-react.md
@@ -19,7 +19,7 @@ import { RichText } from '@optimizely/cms-sdk/react/richText';
 function Article({ content }) {
   return (
     <div>
-      <RichText content={content.body?.json} />
+      <RichText content={content.body?.json} context={content.__context} />
     </div>
   );
 }
@@ -47,6 +47,34 @@ The rich text content from Optimizely CMS. This is typically accessed from a con
 
 ```tsx
 <RichText content={article.body?.json} />
+```
+
+### `context` (Optional)
+
+**Type:** `{ edit?: boolean; preview_token?: string } | undefined`  
+**Default:** `undefined`
+
+**When to use:**
+
+- In Optimizely CMS preview/edit mode
+- When rendering content that contains images
+- To ensure draft images (un published) are accessible during content editing
+
+#### Example: Preview Mode Support
+
+```tsx
+import { RichText } from '@optimizely/cms-sdk/react/richText';
+
+export default function Article({ content }) {
+  return (
+    <article>
+      <h1>{content.heading}</h1>
+
+      {/* Pass context to enable preview mode for images */}
+      <RichText content={content.body?.json} context={content.__context} />
+    </article>
+  );
+}
 ```
 
 ### `elements`
@@ -202,6 +230,7 @@ const CodeExample = ({ content }) => (
   <div className="code-display">
     <RichText
       content={content}
+      context={content.__context}
       decodeHtmlEntities={false}
       elements={{
         paragraph: ({ children }) => <pre>{children}</pre>,
@@ -274,6 +303,7 @@ export default function Article({ content }) {
           code: CustomCode,
         }}
         decodeHtmlEntities={true}
+        context={content.__context}
       />
     </article>
   );
@@ -366,6 +396,7 @@ function Article({ content }) {
   return (
     <RichText
       content={content.body?.json}
+      context={content.__context}
       elements={{
         'unknown-element': UnknownElement, // Handle specific unknown element type
         'custom-element': CustomElement, // Your custom CMS element
@@ -412,6 +443,7 @@ function Article({ content }) {
   return (
     <RichText
       content={content.body?.json}
+      context={content.__context}
       elements={{
         'video-embed': VideoElement,
         'callout-box': CalloutElement,
@@ -792,6 +824,7 @@ This attribute and CSS property processing ensures that rich text content from O
 ```tsx
 <RichText
   content={page.content?.json}
+  context={content.__context}
   elements={{
     link: ({ children, element }) => (
       <TrackableLink url={element.url} eventName="content-click">
@@ -800,4 +833,37 @@ This attribute and CSS property processing ensures that rich text content from O
     ),
   }}
 />
+```
+
+### Preview/Edit Mode
+
+When rendering content in Optimizely's preview or edit mode, pass the `context` prop to ensure images display correctly with preview tokens:
+
+```tsx
+import { RichText } from '@optimizely/cms-sdk/react/richText';
+import { getPreviewUtils } from '@optimizely/cms-sdk/react';
+
+export default function BlogPost({ content }) {
+  const { pa } = getPreviewUtils(content);
+
+  return (
+    <article>
+      {/* Standard image with preview support */}
+      {content.heroImage && (
+        <img
+          src={getPreviewUtils(content).src(content.heroImage)}
+          alt={content.heroImage.alt}
+          {...pa('heroImage')}
+        />
+      )}
+
+      {/* Rich text with automatic preview token support for embedded images */}
+      <RichText
+        content={content.bodyText?.json}
+        context={content.__context}
+        {...pa('bodyText')}
+      />
+    </article>
+  );
+}
 ```

--- a/packages/optimizely-cms-sdk/src/components/richText/renderer.ts
+++ b/packages/optimizely-cms-sdk/src/components/richText/renderer.ts
@@ -173,6 +173,14 @@ export interface RichTextPropsBase<
    * Whether to decode HTML entities in text content
    */
   decodeHtmlEntities?: boolean;
+
+  /**
+   * Content context for preview mode
+   */
+  context?: {
+    edit?: boolean;
+    preview_token?: string;
+  };
 }
 
 /**

--- a/packages/optimizely-cms-sdk/src/react/richText/component.tsx
+++ b/packages/optimizely-cms-sdk/src/react/richText/component.tsx
@@ -27,13 +27,14 @@ export const RichText: React.FC<RichTextProps> = ({
   elements: customElements = {},
   leafs: customLeafs = {},
   decodeHtmlEntities = true,
+  context,
   ...htmlAttributes
 }) => {
   const nodes = Array.isArray(content?.children) ? content.children : [];
 
   // Merge default components with user overrides
   const elements = {
-    ...generateDefaultElements(),
+    ...generateDefaultElements(context?.preview_token),
     ...customElements,
   };
 

--- a/packages/optimizely-cms-sdk/src/react/richText/lib.ts
+++ b/packages/optimizely-cms-sdk/src/react/richText/lib.ts
@@ -20,15 +20,13 @@ import { appendToken } from '../../util/preview.js';
  * React-specific element renderer props (extends shared props with React children)
  */
 export interface ElementRendererProps
-  extends BaseElementRendererProps,
-    PropsWithChildren {}
+  extends BaseElementRendererProps, PropsWithChildren {}
 
 /**
  * React-specific props for link elements with type safety
  */
 export interface LinkElementProps
-  extends Omit<BaseElementRendererProps, 'element'>,
-    PropsWithChildren {
+  extends Omit<BaseElementRendererProps, 'element'>, PropsWithChildren {
   element: LinkElement;
 }
 
@@ -36,8 +34,7 @@ export interface LinkElementProps
  * React-specific props for image elements with type safety
  */
 export interface ImageElementProps
-  extends Omit<BaseElementRendererProps, 'element'>,
-    PropsWithChildren {
+  extends Omit<BaseElementRendererProps, 'element'>, PropsWithChildren {
   element: ImageElement;
 }
 
@@ -45,8 +42,7 @@ export interface ImageElementProps
  * React-specific props for table elements with type safety
  */
 export interface TableElementProps
-  extends Omit<BaseElementRendererProps, 'element'>,
-    PropsWithChildren {
+  extends Omit<BaseElementRendererProps, 'element'>, PropsWithChildren {
   element: TableElement;
 }
 
@@ -54,8 +50,7 @@ export interface TableElementProps
  * React-specific props for table cell elements with type safety
  */
 export interface TableCellElementRendererProps
-  extends Omit<BaseElementRendererProps, 'element'>,
-    PropsWithChildren {
+  extends Omit<BaseElementRendererProps, 'element'>, PropsWithChildren {
   element: TableCellElement;
 }
 
@@ -68,8 +63,7 @@ export type ElementProps = ElementRendererProps;
  * React-specific leaf renderer props (extends shared props with React children)
  */
 export interface LeafRendererProps
-  extends BaseLeafRendererProps,
-    PropsWithChildren {}
+  extends BaseLeafRendererProps, PropsWithChildren {}
 
 /**
  * Prop type used for custom Leaf components
@@ -121,7 +115,8 @@ export type LeafMap = BaseLeafMap<LeafRenderer>;
  * React-specific RichText props
  */
 export interface RichTextProps
-  extends RichTextPropsBase<ElementRenderer, LeafRenderer>,
+  extends
+    RichTextPropsBase<ElementRenderer, LeafRenderer>,
     Omit<React.HTMLAttributes<HTMLDivElement>, 'content'> {}
 
 /**
@@ -416,7 +411,7 @@ const HTML_ATTRIBUTE_ELEMENTS = new Set(['table', 'img', 'input', 'canvas']);
  */
 export function toReactProps(
   attributes: Record<string, unknown>,
-  elementType?: string
+  elementType?: string,
 ): Record<string, unknown> {
   const reactProps: Record<string, unknown> = {};
   const styleProps: Record<string, string> = {};
@@ -505,7 +500,7 @@ function parseStyleString(styleString: string): Record<string, string> {
  */
 export function createHtmlComponent<T extends keyof JSX.IntrinsicElements>(
   tag: T,
-  config: HtmlComponentConfig = {}
+  config: HtmlComponentConfig = {},
 ): ElementRenderer {
   const Component: ElementRenderer = ({ children, attributes, element }) => {
     // Convert to React props and merge with config, passing element type for context
@@ -535,7 +530,7 @@ export function createHtmlComponent<T extends keyof JSX.IntrinsicElements>(
  */
 export function createLinkComponent<T extends keyof JSX.IntrinsicElements>(
   tag: T = 'a' as T,
-  config: HtmlComponentConfig = {}
+  config: HtmlComponentConfig = {},
 ): LinkElementRenderer {
   const Component: LinkElementRenderer = ({
     children,
@@ -575,7 +570,7 @@ export function createLinkComponent<T extends keyof JSX.IntrinsicElements>(
 export function createImageComponent<T extends keyof JSX.IntrinsicElements>(
   tag: T = 'img' as T,
   config: HtmlComponentConfig = {},
-  previewToken?: string
+  previewToken?: string,
 ): ImageElementRenderer {
   const Component: ImageElementRenderer = ({
     children,
@@ -585,9 +580,14 @@ export function createImageComponent<T extends keyof JSX.IntrinsicElements>(
     // Convert to React props and merge with config
     const reactProps = toReactProps(attributes || {}, tag as string);
 
+    // Append preview token to image URL if provided
+    const src = previewToken
+      ? appendToken(element.url, previewToken)
+      : element.url;
+
     // Type-safe access to image properties
     const imageProps = {
-      src: element.url ? appendToken(element.url, previewToken) : element.url,
+      src: src,
       alt: element.alt,
       title: element.title,
       width: element.width,
@@ -617,7 +617,7 @@ export function createImageComponent<T extends keyof JSX.IntrinsicElements>(
  */
 export function createTableComponent<T extends keyof JSX.IntrinsicElements>(
   tag: T = 'table' as T,
-  config: HtmlComponentConfig = {}
+  config: HtmlComponentConfig = {},
 ): TableElementRenderer {
   const Component: TableElementRenderer = ({
     children,
@@ -647,7 +647,7 @@ export function createTableComponent<T extends keyof JSX.IntrinsicElements>(
  */
 export function createTableCellComponent<T extends keyof JSX.IntrinsicElements>(
   tag: T,
-  config: HtmlComponentConfig = {}
+  config: HtmlComponentConfig = {},
 ): TableCellElementRenderer {
   const Component: TableCellElementRenderer = ({
     children,
@@ -677,7 +677,7 @@ export function createTableCellComponent<T extends keyof JSX.IntrinsicElements>(
  */
 export function createLeafComponent<T extends keyof JSX.IntrinsicElements>(
   tag: T,
-  config: HtmlComponentConfig = {}
+  config: HtmlComponentConfig = {},
 ): LeafRenderer {
   const Component: LeafRenderer = ({ children, attributes }) => {
     // Convert to React props and merge with config
@@ -709,38 +709,38 @@ export function generateDefaultElements(previewToken?: string): ElementMap {
       case 'link':
         elementMap[type] = createLinkComponent(
           'a',
-          config.config
+          config.config,
         ) as ElementRenderer;
         break;
       case 'image':
         elementMap[type] = createImageComponent(
           'img',
           config.config,
-          previewToken
+          previewToken,
         ) as ElementRenderer;
         break;
       case 'table':
         elementMap[type] = createTableComponent(
           'table',
-          config.config
+          config.config,
         ) as ElementRenderer;
         break;
       case 'td':
         elementMap[type] = createTableCellComponent(
           'td',
-          config.config
+          config.config,
         ) as ElementRenderer;
         break;
       case 'th':
         elementMap[type] = createTableCellComponent(
           'th',
-          config.config
+          config.config,
         ) as ElementRenderer;
         break;
       default:
         elementMap[type] = createHtmlComponent(
           config.tag as keyof JSX.IntrinsicElements,
-          config.config
+          config.config,
         );
         break;
     }

--- a/packages/optimizely-cms-sdk/src/react/richText/lib.ts
+++ b/packages/optimizely-cms-sdk/src/react/richText/lib.ts
@@ -14,6 +14,7 @@ import {
   type TableElement,
   type TableCellElement,
 } from '../../components/richText/renderer.js';
+import { appendToken } from '../../util/preview.js';
 
 /**
  * React-specific element renderer props (extends shared props with React children)
@@ -573,7 +574,8 @@ export function createLinkComponent<T extends keyof JSX.IntrinsicElements>(
  */
 export function createImageComponent<T extends keyof JSX.IntrinsicElements>(
   tag: T = 'img' as T,
-  config: HtmlComponentConfig = {}
+  config: HtmlComponentConfig = {},
+  previewToken?: string
 ): ImageElementRenderer {
   const Component: ImageElementRenderer = ({
     children,
@@ -585,7 +587,7 @@ export function createImageComponent<T extends keyof JSX.IntrinsicElements>(
 
     // Type-safe access to image properties
     const imageProps = {
-      src: element.url,
+      src: element.url ? appendToken(element.url, previewToken) : element.url,
       alt: element.alt,
       title: element.title,
       width: element.width,
@@ -698,7 +700,7 @@ export function createLeafComponent<T extends keyof JSX.IntrinsicElements>(
 /**
  * Generate complete element map from core defaults with type-safe specialized components
  */
-export function generateDefaultElements(): ElementMap {
+export function generateDefaultElements(previewToken?: string): ElementMap {
   const elementMap: ElementMap = {};
 
   Object.entries(defaultElementTypeMap).forEach(([type, config]) => {
@@ -713,7 +715,8 @@ export function generateDefaultElements(): ElementMap {
       case 'image':
         elementMap[type] = createImageComponent(
           'img',
-          config.config
+          config.config,
+          previewToken
         ) as ElementRenderer;
         break;
       case 'table':

--- a/templates/alloy-template/src/components/News.tsx
+++ b/templates/alloy-template/src/components/News.tsx
@@ -44,7 +44,11 @@ type NewsPageProps = {
 
 function ComponentWrapper({ children, node }: ComponentContainerProps) {
   const { pa } = getPreviewUtils(node);
-  return <div {...pa(node)} className="w-full block">{children}</div>;
+  return (
+    <div {...pa(node)} className="w-full block">
+      {children}
+    </div>
+  );
 }
 
 function News({ content }: NewsPageProps) {
@@ -76,6 +80,7 @@ function News({ content }: NewsPageProps) {
             {/* Main Body Content */}
             <RichText
               {...pa('main_body')}
+              context={content.__context}
               content={content.main_body?.json}
               className="space-y-4 sm:space-y-6"
             />

--- a/templates/alloy-template/src/components/Product.tsx
+++ b/templates/alloy-template/src/components/Product.tsx
@@ -85,6 +85,7 @@ function Product({ content }: ProductProps) {
             {/* Main Body Content */}
             <RichText
               {...pa('main_body')}
+              context={content.__context}
               content={content.main_body?.json}
               className="space-y-4 sm:space-y-6"
             />

--- a/templates/alloy-template/src/components/Standard.tsx
+++ b/templates/alloy-template/src/components/Standard.tsx
@@ -44,7 +44,11 @@ type StandardPageProps = {
 
 function ComponentWrapper({ children, node }: ComponentContainerProps) {
   const { pa } = getPreviewUtils(node);
-  return <div {...pa(node)} className="w-full block">{children}</div>;
+  return (
+    <div {...pa(node)} className="w-full block">
+      {children}
+    </div>
+  );
 }
 
 function Standard({ content }: StandardPageProps) {
@@ -72,6 +76,7 @@ function Standard({ content }: StandardPageProps) {
           {/* Main Body Content */}
           <RichText
             {...pa('main_body')}
+            context={content.__context}
             content={content.main_body?.json}
             className="space-y-4 sm:space-y-6"
           />

--- a/templates/alloy-template/src/components/base/Article.tsx
+++ b/templates/alloy-template/src/components/base/Article.tsx
@@ -33,7 +33,11 @@ function Article({ content }: ArticlePageProps) {
     <div>
       <h1 {...pa('title')}>{content.title}</h1>
       <p {...pa('description')}>{content.description}</p>
-      <RichText {...pa('body')} content={content.body?.json} />
+      <RichText
+        {...pa('body')}
+        content={content.body?.json}
+        context={content.__context}
+      />
     </div>
   );
 }

--- a/templates/alloy-template/src/components/base/Editorial.tsx
+++ b/templates/alloy-template/src/components/base/Editorial.tsx
@@ -21,7 +21,13 @@ type EditorialProps = {
 
 function Editorial({ content }: EditorialProps) {
   const { pa } = getPreviewUtils(content);
-  return <RichText {...pa('main_body')} content={content.main_body?.json} />;
+  return (
+    <RichText
+      {...pa('main_body')}
+      content={content.main_body?.json}
+      context={content.__context}
+    />
+  );
 }
 
 export default Editorial;


### PR DESCRIPTION
- Introduce a new param called `context` which allows `RichText` to access the `preview_token` and append it to image source.