### PR TITLE
CMS-51420 Update TypeScript configuration for improved module interoperability

### DIFF
--- a/packages/optimizely-cms-cli/tsconfig.json
+++ b/packages/optimizely-cms-cli/tsconfig.json
@@ -7,10 +7,11 @@
     "declaration": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["./src/**/*"],
   "exclude": ["./src/tests/**/*", "./src/**/*.test.ts"]

--- a/packages/optimizely-cms-sdk/package.json
+++ b/packages/optimizely-cms-sdk/package.json
@@ -3,27 +3,32 @@
   "version": "1.0.0",
   "description": "JavaScript tools for integration with Optimizely CMS",
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "exports": {
     ".": {
+      "types": "./dist/cjs/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./react/server": {
+      "types": "./dist/cjs/react/server.d.ts",
       "import": "./dist/esm/react/server.js",
       "require": "./dist/cjs/react/server.js"
     },
     "./react/client": {
+      "types": "./dist/cjs/react/client.d.ts",
       "import": "./dist/esm/react/client.js",
       "require": "./dist/cjs/react/client.js"
     },
     "./react/richText": {
+      "types": "./dist/cjs/react/richText/index.d.ts",
       "import": "./dist/esm/react/richText/index.js",
       "require": "./dist/cjs/react/richText/index.js"
     },
     "./buildConfig": {
-      "import": "./dist/esm/model/buildConfig.js",
-      "types": "./dist/cjs/model/buildConfig.d.ts"
+      "types": "./dist/cjs/model/buildConfig.d.ts",
+      "import": "./dist/esm/model/buildConfig.js"
     }
   },
   "repository": {

--- a/packages/optimizely-cms-sdk/tsconfig.base.json
+++ b/packages/optimizely-cms-sdk/tsconfig.base.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "sourceMap": true,
     "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
- Fix deprecated warning in in **tsconfig** with `esModuleInterop=false`.
- Add  `"sideEffects": false` for better tree shaking.
- Add `types` for exports in modules