### PR TITLE
CMS-51669 Add error util file, translate ignoreDataLossWarnings error and provide base structure for future error translations

### DIFF
--- a/packages/optimizely-cms-cli/src/commands/config/push.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/push.ts
@@ -13,6 +13,7 @@ import {
 import { mapContentToManifest } from '../../mapper/contentToPackage.js';
 import { pathToFileURL } from 'node:url';
 import { constants } from 'node:fs';
+import { translateErrorMessage } from '../../utils/errors.js';
 
 export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
   static override args = {
@@ -174,7 +175,6 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
     }
 
     const data = response.data;
-
     if (data.outcomes && data.outcomes.length > 0) {
       console.log(chalk.cyan.bold('\nOutcomes:'));
       for (const r of response.data?.outcomes ?? []) {
@@ -192,7 +192,8 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
     if (data.errors && data.errors.length > 0) {
       console.log(chalk.red.bold('\nErrors:'));
       for (const r of data.errors) {
-        console.log(chalk.dim('  -'), chalk.red(r.message));
+        const errorMessage = translateErrorMessage(r);
+        console.log(chalk.dim('  -'), chalk.red(errorMessage));
       }
       process.exit(1);
     }

--- a/packages/optimizely-cms-cli/src/utils/errors.ts
+++ b/packages/optimizely-cms-cli/src/utils/errors.ts
@@ -1,0 +1,40 @@
+enum IncomingErrorType {
+  DataLossWarning,
+  Unknown,
+}
+
+type PackageImportError = { section?: string | null; message?: string | null };
+
+function getErrorMessageType({
+  section,
+  message,
+}: PackageImportError): IncomingErrorType {
+  if (section === 'contentTypes' && message?.includes('ignoreDataLossWarnings'))
+    return IncomingErrorType.DataLossWarning;
+  return IncomingErrorType.Unknown;
+}
+
+const ignoreDataLossWarningsMessage =
+  "Use the 'ignoreDataLossWarnings' option to apply the changes anyway.";
+const useForceFlagMessage =
+  "Use the '--force' flag to apply the changes anyway.";
+
+function getErrorMessage(
+  errorType: IncomingErrorType,
+  message: string,
+): string {
+  switch (errorType) {
+    case IncomingErrorType.DataLossWarning:
+      return message?.replace(
+        ignoreDataLossWarningsMessage,
+        useForceFlagMessage,
+      );
+    default:
+      return message ?? '';
+  }
+}
+
+export function translateErrorMessage(importError: PackageImportError): string {
+  const errorMessageType = getErrorMessageType(importError);
+  return getErrorMessage(errorMessageType, importError.message ?? '');
+}


### PR DESCRIPTION
Adds error message translation utility to convert API error messages into CLI-friendly instructions.
Updates config push command to translate errors before displaying them to users.
Specifically handles the data loss warning scenario by translating "use ignoreDataLossWarnings option" to "use --force flag".