### PR TITLE
CMS-51738 update graph client and types

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/__test__/getClient.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/getClient.test.ts
@@ -5,7 +5,7 @@ describe('getClient - Critical Edge Cases', () => {
   describe('Basic functionality', () => {
     beforeEach(() => {
       config({
-        key: 'test-key',
+        apiKey: 'test-key',
         graphUrl: 'https://test.optimizely.com/content/v2',
         host: 'test.com',
       });
@@ -15,7 +15,7 @@ describe('getClient - Critical Edge Cases', () => {
       const client = getClient();
 
       expect(client).toBeInstanceOf(GraphClient);
-      expect(client.key).toBe('test-key');
+      expect(client.apiKey).toBe('test-key');
       expect(client.graphUrl).toBe('https://test.optimizely.com/content/v2');
       expect(client.host).toBe('test.com');
     });
@@ -25,7 +25,7 @@ describe('getClient - Critical Edge Cases', () => {
         host: 'override.com',
       });
 
-      expect(client.key).toBe('test-key');
+      expect(client.apiKey).toBe('test-key');
       expect(client.host).toBe('override.com');
     });
   });
@@ -49,27 +49,27 @@ describe('getClient - Critical Edge Cases', () => {
   describe('CRITICAL: undefined/null key validation', () => {
     test('should throw error for empty string key in config', () => {
       expect(() => {
-        config({ key: '' });
+        config({ apiKey: '' });
       }).toThrow('Invalid Optimizely Graph API key');
     });
 
     test('should throw error for whitespace-only key in config', () => {
       expect(() => {
-        config({ key: '   ' });
+        config({ apiKey: '   ' });
       }).toThrow('Invalid Optimizely Graph API key');
     });
 
     test('should throw error for undefined key in config (runtime behavior)', () => {
       expect(() => {
         // @ts-expect-error - Testing runtime behavior
-        config({ key: undefined });
+        config({ apiKey: undefined });
       }).toThrow('Invalid Optimizely Graph API key');
     });
 
     test('should throw error for null key in config (runtime behavior)', () => {
       expect(() => {
         // @ts-expect-error - Testing runtime behavior
-        config({ key: null });
+        config({ apiKey: null });
       }).toThrow('Invalid Optimizely Graph API key');
     });
 
@@ -77,14 +77,14 @@ describe('getClient - Critical Edge Cases', () => {
     test('should throw error with helpful message mentioning environment variables', () => {
       expect(() => {
         // @ts-expect-error - Testing runtime behavior
-        config({ key: undefined });
+        config({ apiKey: undefined });
       }).toThrow('process.env.OPTIMIZELY_GRAPH_SINGLE_KEY');
     });
   });
 
   describe('CRITICAL: undefined/null graphUrl', () => {
     test('should use default graphUrl when undefined in config', () => {
-      config({ key: 'test-key', graphUrl: undefined });
+      config({ apiKey: 'test-key', graphUrl: undefined });
       const client = getClient();
 
       expect(client.graphUrl).toBe('https://cg.optimizely.com/content/v2');
@@ -92,14 +92,14 @@ describe('getClient - Critical Edge Cases', () => {
 
     test('should use default graphUrl when null in config (runtime)', () => {
       // @ts-expect-error - Testing runtime behavior
-      config({ key: 'test-key', graphUrl: null });
+      config({ apiKey: 'test-key', graphUrl: null });
       const client = getClient();
 
       expect(client.graphUrl).toBe('https://cg.optimizely.com/content/v2');
     });
 
     test('should accept empty string graphUrl', () => {
-      config({ key: 'test-key', graphUrl: '' });
+      config({ apiKey: 'test-key', graphUrl: '' });
       const client = getClient();
 
       expect(client.graphUrl).toBe('');
@@ -122,7 +122,7 @@ describe('getClient - Critical Edge Cases', () => {
   describe('CRITICAL: override options with undefined/null', () => {
     beforeEach(() => {
       config({
-        key: 'base-key',
+        apiKey: 'base-key',
         graphUrl: 'https://base.optimizely.com/content/v2',
         host: 'base.com',
       });
@@ -150,10 +150,10 @@ describe('getClient - Critical Edge Cases', () => {
 
   describe('Default values', () => {
     test('should use all defaults when only key is provided', () => {
-      config({ key: 'minimal-key' });
+      config({ apiKey: 'minimal-key' });
       const client = getClient();
 
-      expect(client.key).toBe('minimal-key');
+      expect(client.apiKey).toBe('minimal-key');
       expect(client.graphUrl).toBe('https://cg.optimizely.com/content/v2');
       expect(client.maxFragmentThreshold).toBe(100);
       expect(client.host).toBeUndefined();
@@ -161,14 +161,14 @@ describe('getClient - Critical Edge Cases', () => {
 
     test('should handle config with all optional values undefined', () => {
       config({
-        key: 'test-key',
+        apiKey: 'test-key',
         graphUrl: undefined,
         host: undefined,
         maxFragmentThreshold: undefined,
       });
       const client = getClient();
 
-      expect(client.key).toBe('test-key');
+      expect(client.apiKey).toBe('test-key');
       expect(client.graphUrl).toBe('https://cg.optimizely.com/content/v2');
       expect(client.host).toBeUndefined();
       expect(client.maxFragmentThreshold).toBe(100);

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -22,8 +22,8 @@ import { setContext } from '../context/config.js';
 
 /** Configuration for initializing the Optimizely Graph Client */
 export type GraphOptions = {
-  /** Your Optimizely Graph API key */
-  key: string;
+  /** Your Optimizely Graph API key (Single key in CMS) */
+  apiKey: string;
   /** Optional custom Graph URL (defaults to production: https://cg.optimizely.com/content/v2) */
   graphUrl?: string;
   /** Optional default host for path filtering */
@@ -285,7 +285,7 @@ function decorateWithContext(obj: any, params: PreviewParams): any {
 }
 
 export class GraphClient {
-  key: string;
+  apiKey: string;
   graphUrl: string;
   maxFragmentThreshold: number;
   host?: string;
@@ -293,8 +293,8 @@ export class GraphClient {
   slot?: GraphSlot;
 
   // The key is required, other options have defaults or can be set globally
-  constructor(key: string, options: Omit<GraphOptions, 'key'> = {}) {
-    this.key = key;
+  constructor(apiKey: string, options: Omit<GraphOptions, 'apiKey'> = {}) {
+    this.apiKey = apiKey;
     this.graphUrl = options.graphUrl ?? 'https://cg.optimizely.com/content/v2';
     this.maxFragmentThreshold = options.maxFragmentThreshold ?? 100;
     this.host = options.host;
@@ -312,16 +312,14 @@ export class GraphClient {
   ): Promise<any> {
     const url = new URL(this.graphUrl);
 
-    if (!previewToken) {
-      url.searchParams.append('auth', this.key);
-    }
-
     // Append cache parameter to control caching behavior
     url.searchParams.append('cache', cache.toString());
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
-      Authorization: previewToken ? `Bearer ${previewToken}` : '',
+      Authorization: previewToken
+        ? `Bearer ${previewToken}`
+        : `epi-single ${this.apiKey}`,
     };
 
     if (slot === 'New') {
@@ -450,8 +448,12 @@ export class GraphClient {
     const cacheEnabled = options?.cache ?? this.cache;
     const activeSlot = options?.slot ?? this.slot;
 
-    const { contentTypeName, damEnabled } =
-      await this.getContentMetaData(input, undefined, cacheEnabled, activeSlot);
+    const { contentTypeName, damEnabled } = await this.getContentMetaData(
+      input,
+      undefined,
+      cacheEnabled,
+      activeSlot,
+    );
 
     if (!contentTypeName) {
       return [];
@@ -463,7 +465,13 @@ export class GraphClient {
         damEnabled,
         this.maxFragmentThreshold,
       );
-      const response = (await this.request(query, input, undefined, cacheEnabled, activeSlot)) as ItemsResponse<T>;
+      const response = (await this.request(
+        query,
+        input,
+        undefined,
+        cacheEnabled,
+        activeSlot,
+      )) as ItemsResponse<T>;
 
       return response?._Content?.items.map(removeTypePrefix);
     } catch (error) {
@@ -882,7 +890,7 @@ export function getGraphConfig(): GraphOptions | null {
  * import { config } from '@optimizely/cms-sdk';
  *
  * config({
- *   key: process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!,
+ *   apiKey: process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!,
  *   graphUrl: process.env.OPTIMIZELY_GRAPH_GATEWAY, // optional
  *   host: 'example.com', // optional
  * });
@@ -894,9 +902,9 @@ export function getGraphConfig(): GraphOptions | null {
  */
 export function config(options: GraphOptions) {
   if (
-    !options.key ||
-    typeof options.key !== 'string' ||
-    options.key.trim().length === 0
+    !options.apiKey ||
+    typeof options.apiKey !== 'string' ||
+    options.apiKey.trim().length === 0
   ) {
     throw new OptimizelyGraphError(
       'Invalid Optimizely Graph API key: key must be a non-empty string. ' +
@@ -921,7 +929,7 @@ export function config(options: GraphOptions) {
  * import { config } from '@optimizely/cms-sdk';
  *
  * config({
- *   key: process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!,
+ *   apiKey: process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!,
  *   graphUrl: process.env.OPTIMIZELY_GRAPH_GATEWAY, // optional
  *   host: 'example.com', // optional
  * });
@@ -948,5 +956,5 @@ export function getClient(overrideOptions?: Partial<GraphOptions>): GraphClient 
     ...(overrideOptions ?? {}),
   };
 
-  return new GraphClient(options.key, options);
+  return new GraphClient(options.apiKey, options);
 }

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -508,28 +508,29 @@ export class GraphClient {
    * ```
    */
   async getPath(
-    input: string | GraphReference,
+    reference: string | GraphReference,
     options?: GraphGetLinksOptions,
   ) {
     let filter: GraphVariables;
-    if (typeof input === 'string' && input.startsWith('graph://')) {
-      const ref = this.parseGraphReference(input);
+    if (typeof reference === 'string' && reference.startsWith('graph://')) {
+      const ref = this.parseGraphReference(reference);
       filter = {
         ...referenceFilter(ref),
         ...localeFilter(
           options?.locales ?? (ref.locale ? [ref.locale] : undefined),
         ),
       };
-    } else if (typeof input === 'string') {
+    } else if (typeof reference === 'string') {
       filter = {
-        ...pathFilter(input, options?.host ?? this.host),
+        ...pathFilter(reference, options?.host ?? this.host),
         ...localeFilter(options?.locales),
       };
     } else {
       filter = {
-        ...referenceFilter(input),
+        ...referenceFilter(reference),
         ...localeFilter(
-          options?.locales ?? (input.locale ? [input.locale] : undefined),
+          options?.locales ??
+            (reference.locale ? [reference.locale] : undefined),
         ),
       };
     }
@@ -598,28 +599,29 @@ export class GraphClient {
    * ```
    */
   async getItems(
-    input: string | GraphReference,
+    reference: string | GraphReference,
     options?: GraphGetLinksOptions,
   ) {
     let filter: GraphVariables;
-    if (typeof input === 'string' && input.startsWith('graph://')) {
-      const ref = this.parseGraphReference(input);
+    if (typeof reference === 'string' && reference.startsWith('graph://')) {
+      const ref = this.parseGraphReference(reference);
       filter = {
         ...referenceFilter(ref),
         ...localeFilter(
           options?.locales ?? (ref.locale ? [ref.locale] : undefined),
         ),
       };
-    } else if (typeof input === 'string') {
+    } else if (typeof reference === 'string') {
       filter = {
-        ...pathFilter(input, options?.host ?? this.host),
+        ...pathFilter(reference, options?.host ?? this.host),
         ...localeFilter(options?.locales),
       };
     } else {
       filter = {
-        ...referenceFilter(input),
+        ...referenceFilter(reference),
         ...localeFilter(
-          options?.locales ?? (input.locale ? [input.locale] : undefined),
+          options?.locales ??
+            (reference.locale ? [reference.locale] : undefined),
         ),
       };
     }
@@ -796,7 +798,7 @@ export class GraphClient {
    * ```
    */
   async getContent(
-    reference: GraphReference | string,
+    reference: string | GraphReference,
     options?: GraphGetItemOptions,
   ) {
     const ref =

--- a/templates/alloy-template/src/app/layout.tsx
+++ b/templates/alloy-template/src/app/layout.tsx
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
 
 // Configure Optimizely Graph client
 config({
-  key: process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!,
+  apiKey: process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!,
   graphUrl: process.env.OPTIMIZELY_GRAPH_GATEWAY,
 });
 


### PR DESCRIPTION
- Renamed key → apiKey across all types, GraphClient class, config function, tests, and templates.
- Changed authorization from URL query param to header format: epi-single ${apiKey} when no preview token.
- Standardized parameter naming: input → reference in getPath() and getItems() methods for consistency with getContent().
- Fixed code formatting and type order consistency.