### PR TITLE
CMS-51776 Add additional logs for error details

### DIFF
--- a/packages/optimizely-cms-cli/src/commands/config/push.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/push.ts
@@ -152,7 +152,7 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
           ),
         );
       } else {
-        spinner.fail(chalk.red('Error'));
+        spinner.fail(chalk.red(' Error'));
         console.error(
           chalk.red(
             `Error ${response.error.status}: ${response.error.title || 'Unknown error'} (${response.error.code || 'N/A'})`,
@@ -160,6 +160,13 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
         );
         if (response.error.detail) {
           console.error(chalk.dim(response.error.detail));
+        }
+        if (response.error.errors?.length) {
+          for (const [index, err] of response.error.errors.entries()) {
+            console.error((`  - ERROR ${index + 1}`));
+            console.error(chalk.dim(`      [DETAIL] ${err.detail}`));
+            console.error(chalk.dim(`      [FIELD]  ${err.field}\n`));
+          }
         }
       }
 


### PR DESCRIPTION
Enhances error reporting when config push fails by displaying detailed validation errors. When the API returns multiple errors (e.g., field-level validation issues), the command now outputs:

 - Error index/count
 - Detailed error message
 - The specific field that caused the error

This makes it easier to diagnose and fix configuration issues instead of seeing a generic error message.