### PR TITLE
CMS-51815 Add displayName to content types and enhance property metadata handling

### DIFF
--- a/__test__/test-website/src/components/with-display-templates.tsx
+++ b/__test__/test-website/src/components/with-display-templates.tsx
@@ -12,6 +12,7 @@ import {
 
 export const ct1 = contentType({
   key: 'test_c1',
+  displayName: 'Test C1',
   baseType: '_component',
   properties: {
     p1: { type: 'string' },
@@ -21,6 +22,7 @@ export const ct1 = contentType({
 
 export const ct2 = contentType({
   key: 'test_c2',
+  displayName: 'Test C2',
   baseType: '_component',
   properties: {
     p2: { type: 'float' },
@@ -30,17 +32,20 @@ export const ct2 = contentType({
 
 export const ct3 = contentType({
   key: 'test_c3',
+  displayName: 'Test C3',
   baseType: '_experience',
 });
 
 export const ct6 = contentType({
   key: 'test_c6',
+  displayName: 'Test C6',
   baseType: '_component',
   compositionBehaviors: ['elementEnabled', 'sectionEnabled'],
 });
 
 export const ct7 = contentType({
   key: 'test_c7',
+  displayName: 'Test C7',
   baseType: '_component',
   compositionBehaviors: ['elementEnabled', 'sectionEnabled'],
 });

--- a/__test__/test-website/src/components/with-repeated-properties.tsx
+++ b/__test__/test-website/src/components/with-repeated-properties.tsx
@@ -3,41 +3,49 @@ import { contentType } from '@optimizely/cms-sdk';
 export const ctString = contentType({
   baseType: '_component',
   key: 'ct_string',
+  displayName: 'CT String',
   properties: { p1: { type: 'string' } },
 });
 export const ctBoolean = contentType({
   baseType: '_component',
   key: 'ct_boolean',
+  displayName: 'CT Boolean',
   properties: { p1: { type: 'boolean' } },
 });
 export const ctInteger = contentType({
   baseType: '_component',
   key: 'ct_integer',
+  displayName: 'CT Integer',
   properties: { p1: { type: 'integer' } },
 });
 export const ctRich = contentType({
   baseType: '_component',
   key: 'ct_rich',
+  displayName: 'CT Rich',
   properties: { p1: { type: 'richText' } },
 });
 export const ctLink = contentType({
   baseType: '_component',
   key: 'ct_link',
+  displayName: 'CT Link',
   properties: { p1: { type: 'link' } },
 });
 export const ctContentReference = contentType({
   baseType: '_component',
   key: 'ct_contentreference',
+  displayName: 'CT Content Reference',
   properties: { p1: { type: 'contentReference' } },
 });
 export const ctArray = contentType({
   baseType: '_component',
   key: 'ct_array',
+  displayName: 'CT Array',
   properties: { p1: { type: 'array', items: { type: 'string' } } },
 });
 export const ctWithCollision = contentType({
   baseType: '_page',
   key: 'ct_with_collision',
+  displayName: 'CT With Collision',
   properties: {
     collision: {
       type: 'content',

--- a/packages/optimizely-cms-cli/src/generators/contentTypeGenerator.ts
+++ b/packages/optimizely-cms-cli/src/generators/contentTypeGenerator.ts
@@ -198,29 +198,13 @@ function generatePropertiesCode(
 }
 
 /**
- * Generates a single property definition
+ * Pushes common metadata fields to the parts array.
+ * Handles: displayName, description, isRequired, isLocalized, group, sortOrder, indexingType
  */
-function generatePropertyDefinition(
-  property: ContentTypeProperties.All,
-  contentTypeKey: string,
-  componentImports: Set<string>,
-): string {
-  if ('items' in property && property.type === 'array') {
-    // Array type
-    const itemDef = generatePropertyDefinition(
-      property.items,
-      contentTypeKey,
-      componentImports,
-    );
-    return `{\n      type: 'array',\n      items: ${itemDef},\n    }`;
-  }
-
-  // Non-array types
-  const parts: string[] = [];
-
-  // Base properties
-  parts.push(`type: '${property.type}'`);
-
+function pushMetadataFields(
+  property: ContentTypeProperties.Base,
+  parts: string[],
+): void {
   if ('displayName' in property && property.displayName) {
     parts.push(`displayName: '${escapeSingleQuote(property.displayName)}'`);
   }
@@ -248,6 +232,51 @@ function generatePropertyDefinition(
   if ('indexingType' in property && property.indexingType) {
     parts.push(`indexingType: '${property.indexingType}'`);
   }
+}
+
+/**
+ * Generates a single property definition
+ */
+function generatePropertyDefinition(
+  property: ContentTypeProperties.All,
+  contentTypeKey: string,
+  componentImports: Set<string>,
+): string {
+  if ('items' in property && property.type === 'array') {
+    // Array type - generate items definition
+    const itemDef = generatePropertyDefinition(
+      property.items,
+      contentTypeKey,
+      componentImports,
+    );
+
+    // Collect array-level properties
+    const parts: string[] = [];
+    parts.push(`type: 'array'`);
+
+    pushMetadataFields(property, parts);
+
+    // Array-specific properties
+    if ('minItems' in property && property.minItems !== undefined) {
+      parts.push(`minItems: ${property.minItems}`);
+    }
+
+    if ('maxItems' in property && property.maxItems !== undefined) {
+      parts.push(`maxItems: ${property.maxItems}`);
+    }
+
+    parts.push(`items: ${itemDef}`);
+
+    return `{\n      ${parts.join(',\n      ')},\n    }`;
+  }
+
+  // Non-array types
+  const parts: string[] = [];
+
+  // Base properties
+  parts.push(`type: '${property.type}'`);
+
+  pushMetadataFields(property, parts);
 
   // Format (common to many types)
   if ('format' in property && property.format) {

--- a/packages/optimizely-cms-cli/src/generators/manifest.ts
+++ b/packages/optimizely-cms-cli/src/generators/manifest.ts
@@ -57,7 +57,7 @@ export namespace ContentTypeProperties {
     format?: string;
     displayName?: string;
     description?: string;
-    required?: boolean;
+    isRequired?: boolean;
     isLocalized?: boolean;
     group?: string;
     sortOrder?: number;
@@ -122,9 +122,11 @@ export namespace ContentTypeProperties {
   };
 
   // Array type
-  export type Array = {
+  export type Array = Base & {
     type: 'array';
     items: NonArray;
+    minItems?: number;
+    maxItems?: number;
   };
 
   // Union types

--- a/packages/optimizely-cms-cli/src/tests/contentTypeGenerator.test.ts
+++ b/packages/optimizely-cms-cli/src/tests/contentTypeGenerator.test.ts
@@ -164,6 +164,7 @@ describe('generateContentTypeCode', () => {
       const contentType: ContentType = {
         key: 'EnumTest',
         baseType: '_component',
+        displayName: 'Enum Test',
         properties: {
           theme: {
             type: 'string',
@@ -183,6 +184,7 @@ describe('generateContentTypeCode', () => {
       const contentType: ContentType = {
         key: 'EnumTest',
         baseType: '_component',
+        displayName: 'Enum Test',
         properties: {
           theme: {
             type: 'string',
@@ -204,6 +206,7 @@ describe('generateContentTypeCode', () => {
       const contentType: ContentType = {
         key: 'EnumTest',
         baseType: '_component',
+        displayName: 'Enum Test',
         properties: {
           theme: {
             type: 'string',
@@ -225,6 +228,7 @@ describe('generateContentTypeCode', () => {
       const contentType: ContentType = {
         key: 'EnumTest',
         baseType: '_component',
+        displayName: 'Enum Test',
         properties: {
           priority: {
             type: 'integer',
@@ -246,6 +250,7 @@ describe('generateContentTypeCode', () => {
       const contentType: ContentType = {
         key: 'EnumTest',
         baseType: '_component',
+        displayName: 'Enum Test',
         properties: {
           priority: {
             type: 'integer',
@@ -269,6 +274,7 @@ describe('generateContentTypeCode', () => {
       const contentType: ContentType = {
         key: 'EnumTest',
         baseType: '_component',
+        displayName: 'Enum Test',
         properties: {
           priority: {
             type: 'integer',
@@ -292,6 +298,7 @@ describe('generateContentTypeCode', () => {
       const contentType: ContentType = {
         key: 'EnumTest',
         baseType: '_component',
+        displayName: 'Enum Test',
         properties: {
           rating: {
             type: 'float',
@@ -309,6 +316,68 @@ describe('generateContentTypeCode', () => {
       expect(code).toContain("{ value: 1.5, displayName: 'Low' }");
       expect(code).toContain("{ value: 2.5, displayName: 'Medium' }");
       expect(code).toContain("{ value: 3.5, displayName: 'High' }");
+    });
+  });
+
+  describe('array properties', () => {
+    it('should generate array with all metadata properties', () => {
+      const contentType: ContentType = {
+        key: 'ArrayTest',
+        baseType: '_component',
+        displayName: 'Array Test',
+        properties: {
+          p_string_list: {
+            type: 'array',
+            displayName: 'p_string_list testing',
+            isLocalized: true,
+            isRequired: false,
+            group: 'Content',
+            sortOrder: 0,
+            minItems: 5,
+            maxItems: 100,
+            items: {
+              type: 'string',
+              format: 'shortString',
+              maxLength: 100,
+              pattern: '^p$*',
+            },
+          },
+        },
+      };
+      const code = generateContentTypeCode(contentType);
+      expect(code).toContain("type: 'array'");
+      expect(code).toContain("displayName: 'p_string_list testing'");
+      expect(code).toContain('isLocalized: true');
+      expect(code).toContain("group: 'Content'");
+      expect(code).toContain('sortOrder: 0');
+      expect(code).toContain('minItems: 5');
+      expect(code).toContain('maxItems: 100');
+      expect(code).toContain("format: 'shortString'");
+      expect(code).toContain('maxLength: 100');
+      expect(code).toContain("pattern: '^p$*'");
+    });
+
+    it('should handle simple array without metadata', () => {
+      const contentType: ContentType = {
+        key: 'SimpleArray',
+        baseType: '_component',
+        displayName: 'Simple Array',
+        properties: {
+          tags: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      };
+      const code = generateContentTypeCode(contentType);
+      expect(code).toContain("type: 'array'");
+      expect(code).toContain("type: 'string'");
+      // Should not include optional properties
+      expect(code).toContain('displayName:');
+      expect(code).not.toContain('minItems:');
+      expect(code).not.toContain('maxItems:');
     });
   });
 
@@ -377,6 +446,7 @@ describe('generateContentTypeCode', () => {
       const contentType: ContentType = {
         key: 'Product',
         baseType: '_experience',
+        displayName: 'Product',
         properties: {
           seo_properties: {
             type: 'component',


### PR DESCRIPTION
- Update the schemas missing required fields like `displayName`.
- Fix bug when pulling content types from CMS  which omits some properties in items when content type is 'array'.
- Update unit tests.