### PR TITLE
Include read-only types for CMS 13 (PaaS)

### DIFF
--- a/packages/optimizely-cms-cli/src/commands/config/pull.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/pull.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { input, confirm } from '@inquirer/prompts';
 import { BaseCommand } from '../../baseCommand.js';
 import { mkdir } from 'node:fs/promises';
-import { createApiClient } from '../../service/cmsRestClient.js';
+import { createApiClient, isSaasApiGateway, resolveHost } from '../../service/cmsRestClient.js';
 import { generateContentTypeFiles } from '../../generators/contentTypeGenerator.js';
 import { generateDisplayTemplateFiles } from '../../generators/displayTemplateGenerator.js';
 import { ContentType } from '../../generators/manifest.js';
@@ -24,6 +24,11 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
       description: 'Output manifest as JSON to stdout (useful for piping)',
       default: false,
     }),
+    includeReadOnly: Flags.boolean({
+      description:
+        'Include read-only content types in the manifest. Automatically enabled for PaaS/CMS 13 instances; use --no-include-read-only to disable.',
+      allowNo: true,
+    }),
   };
   static override description =
     'Pull content types from CMS. Generates TypeScript files interactively or outputs JSON with --json flag';
@@ -40,12 +45,13 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
    * Fetches the manifest from CMS
    * @throws Error with descriptive message if fetch fails
    */
-  private async fetchManifest(host?: string) {
+  private async fetchManifest(host?: string, includeReadOnly?: boolean) {
     const restClient = await createApiClient(host);
     const { data, error, response } = await restClient.GET('/manifest', {
       params: {
         query: {
           sections: ['contentTypes', 'displayTemplates', 'propertyGroups'],
+          ...(includeReadOnly ? { includeReadOnly: true } : {}),
         },
       },
     });
@@ -80,6 +86,12 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
     // to avoid prompting when output is redirected or piped
     const isInteractive = process.stdout.isTTY === true;
 
+    // Auto-enable includeReadOnly for PaaS (CMS 13) instances; explicit flag overrides auto-detection
+    const includeReadOnly =
+      flags.includeReadOnly !== undefined
+        ? flags.includeReadOnly
+        : !isSaasApiGateway(resolveHost(flags.host));
+
     // The output mode based on flags and environment
     // 1. --json flag explicitly requests JSON output
     // 2. --output flag explicitly requests file generation (even in non-TTY environments like CI)
@@ -102,7 +114,7 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
       }).start();
 
       try {
-        const response = await this.fetchManifest(flags.host);
+        const response = await this.fetchManifest(flags.host, includeReadOnly);
 
         if (!response) {
           spinner.fail('The server did not respond with any content');
@@ -161,7 +173,7 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
 
     try {
       // Pull from CMS
-      const response = await this.fetchManifest(flags.host);
+      const response = await this.fetchManifest(flags.host, includeReadOnly);
 
       if (!response) {
         spinner.fail('The server did not respond with any content');

--- a/packages/optimizely-cms-cli/src/commands/config/pull.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/pull.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { input, confirm } from '@inquirer/prompts';
 import { BaseCommand } from '../../baseCommand.js';
 import { mkdir } from 'node:fs/promises';
-import { createApiClient, isSaasApiGateway, resolveHost } from '../../service/cmsRestClient.js';
+import { createApiClient } from '../../service/cmsRestClient.js';
 import { generateContentTypeFiles } from '../../generators/contentTypeGenerator.js';
 import { generateDisplayTemplateFiles } from '../../generators/displayTemplateGenerator.js';
 import { ContentType } from '../../generators/manifest.js';
@@ -25,9 +25,10 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
       default: false,
     }),
     includeReadOnly: Flags.boolean({
+      aliases: ['include-read-only'],
       description:
-        'Include read-only content types in the manifest. Automatically enabled for PaaS/CMS 13 instances; use --no-include-read-only to disable.',
-      allowNo: true,
+        'Include read-only content types in the manifest. This may include system-generated content types that are not editable in the CMS.',
+      default: false,
     }),
   };
   static override description =
@@ -37,6 +38,7 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
     '<%= config.bin %> <%= command.id %> --output ./src/types',
     '<%= config.bin %> <%= command.id %> --group',
     '<%= config.bin %> <%= command.id %> --output ./src/types --group',
+    '<%= config.bin %> <%= command.id %> --include-read-only',
     '<%= config.bin %> <%= command.id %> --json > manifest.json',
     '<%= config.bin %> <%= command.id %> --json | jq .contentTypes',
   ];
@@ -51,7 +53,7 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
       params: {
         query: {
           sections: ['contentTypes', 'displayTemplates', 'propertyGroups'],
-          ...(includeReadOnly ? { includeReadOnly: true } : {}),
+          ...(includeReadOnly ? { includeReadOnly } : {}),
         },
       },
     });
@@ -86,17 +88,21 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
     // to avoid prompting when output is redirected or piped
     const isInteractive = process.stdout.isTTY === true;
 
-    // Auto-enable includeReadOnly for PaaS (CMS 13) instances; explicit flag overrides auto-detection
-    const includeReadOnly =
-      flags.includeReadOnly !== undefined
-        ? flags.includeReadOnly
-        : !isSaasApiGateway(resolveHost(flags.host));
-
     // The output mode based on flags and environment
     // 1. --json flag explicitly requests JSON output
     // 2. --output flag explicitly requests file generation (even in non-TTY environments like CI)
     // 3. Fallback to TTY detection for backward compatibility (non-interactive → JSON)
     const shouldOutputJson = flags.json || (!flags.output && !isInteractive);
+
+    const includeReadOnly = flags.includeReadOnly;
+
+    if (includeReadOnly) {
+      this.log(
+        chalk.yellow(
+          'Pulling all content types including read-only ones. This may include system-generated content types that are not editable in the CMS.',
+        ),
+      );
+    }
 
     // If JSON output mode, output manifest to stdout
     if (shouldOutputJson) {
@@ -352,4 +358,5 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
     }
   }
 }
+
 

--- a/packages/optimizely-cms-cli/src/service/cmsRestClient.ts
+++ b/packages/optimizely-cms-cli/src/service/cmsRestClient.ts
@@ -9,9 +9,23 @@ import { paths } from './apiSchema/openapi-schema-types.js';
  * @param url - The URL to check
  * @returns True if the URL is a SaaS API gateway, false otherwise
  */
-function isSaasApiGateway(url: string): boolean {
+export function isSaasApiGateway(url: string): boolean {
   // Matches: api.cms.optimizely.com, api.cmstest.optimizely.com, api-<tenant>.cms*.optimizely.com
   return /^https:\/\/api(-[^.]+)?\.cms[^.]*\.optimizely\.com$/.test(url);
+}
+
+const DEFAULT_GATEWAY_URL = 'https://api.cms.optimizely.com';
+
+/**
+ * Resolves the effective CMS host, falling back to the environment variable and
+ * then the default SaaS gateway URL. Trailing slashes are stripped.
+ */
+export function resolveHost(host?: string): string {
+  return (
+    host ||
+    process.env.OPTIMIZELY_CMS_API_URL ||
+    DEFAULT_GATEWAY_URL
+  ).replace(/\/$/, '');
 }
 
 /**
@@ -23,12 +37,9 @@ function isSaasApiGateway(url: string): boolean {
  */
 function rootUrl(options?: { host?: string; omitVersion?: boolean }): string {
   const API_VERSION = 'v1';
-  const DEFAULT_GATEWAY_URL = 'https://api.cms.optimizely.com';
-  const host = options?.host;
   const omitVersion = options?.omitVersion ?? false;
 
-  // Remove trailing slash if present for consistency
-  const baseUrl = (host || process.env.OPTIMIZELY_CMS_API_URL || DEFAULT_GATEWAY_URL).replace(/\/$/, '');
+  const baseUrl = resolveHost(options?.host);
 
   // PaaS instances always require /_cms prefix and version
   if (!isSaasApiGateway(baseUrl)) {

--- a/packages/optimizely-cms-cli/src/service/cmsRestClient.ts
+++ b/packages/optimizely-cms-cli/src/service/cmsRestClient.ts
@@ -4,28 +4,24 @@ import { credentialErrors } from './error.js';
 import { OAuthPaths } from './apiSchema/gateway-auth-types.js';
 import { paths } from './apiSchema/openapi-schema-types.js';
 
+const DEFAULT_GATEWAY_URL = 'https://api.cms.optimizely.com';
+
 /**
  * Determines if the provided URL matches the pattern of a SaaS API gateway.
  * @param url - The URL to check
  * @returns True if the URL is a SaaS API gateway, false otherwise
  */
-export function isSaasApiGateway(url: string): boolean {
+function isSaasApiGateway(url: string): boolean {
   // Matches: api.cms.optimizely.com, api.cmstest.optimizely.com, api-<tenant>.cms*.optimizely.com
   return /^https:\/\/api(-[^.]+)?\.cms[^.]*\.optimizely\.com$/.test(url);
 }
-
-const DEFAULT_GATEWAY_URL = 'https://api.cms.optimizely.com';
 
 /**
  * Resolves the effective CMS host, falling back to the environment variable and
  * then the default SaaS gateway URL. Trailing slashes are stripped.
  */
-export function resolveHost(host?: string): string {
-  return (
-    host ||
-    process.env.OPTIMIZELY_CMS_API_URL ||
-    DEFAULT_GATEWAY_URL
-  ).replace(/\/$/, '');
+function resolveHost(host?: string): string {
+  return (host || process.env.OPTIMIZELY_CMS_API_URL || DEFAULT_GATEWAY_URL).replace(/\/$/, '');
 }
 
 /**
@@ -114,4 +110,5 @@ export async function createApiClient(host?: string) {
   const client = await createRestApiClient({ ...cred, host });
   return client;
 }
+
 


### PR DESCRIPTION
We're building a head for the CMS 13 PaaS version which means we need all types pulled from the CMS, not just the ones created in the CMS (or pushed by the REST API). 

This is the implementation we use in a custom build internally. 