### PR TITLE
CMS-46677 Add contracts support

### DIFF
--- a/docs/3-modelling.md
+++ b/docs/3-modelling.md
@@ -151,6 +151,9 @@ Array properties support:
 
 > [!IMPORTANT]
 > When using `type: 'content'` or `type: 'contentReference'` within array items, always specify `allowedTypes` or `restrictedTypes`. Without these constraints, the SDK will generate nested GraphQL fragments for all possible content types, causing severe performance issues and very slow queries.
+>
+> [!TIP]
+> You can use contracts in `allowedTypes` to allow all content types that extend a specific contract. See the [Content Relationships](#content-relationships) section for examples.
 
 #### Component Property
 
@@ -244,6 +247,7 @@ const BlogPageContentType = contentType({
 - Specific content types: `[ArticleContentType, VideoContentType]`
 - Base types: `['_page', '_component']`
 - Self-reference: `['_self']` to allow the same content type
+- Contracts: `[SEOContract]` to allow all content types that extend that contract
 
 **`restrictedTypes`** - Blacklist of content types that cannot be selected. Uses the same format as `allowedTypes`.
 
@@ -280,9 +284,200 @@ const ComponentFolderContentType = contentType({
 - Self-reference: `['_self']`
 - Wildcard: `['*']` to allow all types
 
+## Contracts
+
+Contracts enable you to define reusable sets of properties that can be shared across multiple content types. This promotes consistency, reduces duplication, and makes it easier to maintain common property sets across your content model.
+
+### Creating a Contract
+
+Use the `contract` function to define a reusable set of properties:
+
+```ts
+import { contract, contentType } from '@optimizely/cms-sdk';
+
+export const SEOContract = contract({
+  key: 'SEO',
+  displayName: 'SEO Properties',
+  properties: {
+    metaTitle: {
+      type: 'string',
+      displayName: 'Meta Title',
+      description: 'SEO title for search engines',
+      maxLength: 60,
+      group: 'seo',
+    },
+    metaDescription: {
+      type: 'string',
+      displayName: 'Meta Description',
+      description: 'SEO description for search engines',
+      maxLength: 160,
+      group: 'seo',
+    },
+    ogImage: {
+      type: 'contentReference',
+      allowedTypes: ['_image'],
+      displayName: 'Open Graph Image',
+      description: 'Image for social media sharing',
+      group: 'seo',
+    },
+  },
+});
+```
+
+### Using Contracts with Content Types
+
+Content types can extend one or multiple contracts using the `extends` property:
+
+```ts
+// Extend a single contract
+const ArticleContentType = contentType({
+  key: 'Article',
+  baseType: '_page',
+  extends: SEOContract, // Inherits metaTitle, metaDescription, ogImage
+  properties: {
+    heading: {
+      type: 'string',
+      displayName: 'Article Heading',
+    },
+    body: {
+      type: 'richText',
+      displayName: 'Article Body',
+    },
+  },
+});
+```
+
+### Extending Multiple Contracts
+
+A content type can extend multiple contracts by passing an array:
+
+```ts
+const TrackingContract = contract({
+  key: 'Tracking',
+  displayName: 'Analytics Tracking',
+  properties: {
+    analyticsId: {
+      type: 'string',
+      displayName: 'Analytics ID',
+      group: 'tracking',
+    },
+    trackingEnabled: {
+      type: 'boolean',
+      displayName: 'Enable Tracking',
+      group: 'tracking',
+    },
+  },
+});
+
+const ProductPageContentType = contentType({
+  key: 'ProductPage',
+  baseType: '_page',
+  extends: [SEOContract, TrackingContract], // Multiple contracts
+  properties: {
+    productName: {
+      type: 'string',
+      displayName: 'Product Name',
+    },
+    price: {
+      type: 'float',
+      displayName: 'Price',
+    },
+  },
+});
+```
+
+### Property Merging Behavior
+
+When a content type extends contracts:
+
+1. All contract properties are merged into the content type
+2. If multiple contracts define the same property key, the **rightmost contract** wins
+3. Properties defined directly on the content type override any inherited properties with the same key
+
+```ts
+const Contract1 = contract({
+  key: 'Contract1',
+  displayName: 'Contract 1',
+  properties: {
+    title: { type: 'string', displayName: 'Title from Contract 1' },
+    description: { type: 'string', displayName: 'Description' },
+  },
+});
+
+const Contract2 = contract({
+  key: 'Contract2',
+  displayName: 'Contract 2',
+  properties: {
+    // Overrides Contract1
+    title: { type: 'string', displayName: 'Title from Contract 2' }, 
+  },
+});
+
+const MyContentType = contentType({
+  key: 'MyType',
+  baseType: '_page',
+  extends: [Contract1, Contract2],
+  properties: {
+    // Overrides both contracts
+    title: { type: 'string', displayName: 'My Custom Title' },
+  },
+});
+
+// Result: MyContentType has:
+// - title: "My Custom Title" (from content type)
+// - description: "Description" (from Contract1)
+```
+
+
+#### Using Contracts in Content Relationships
+
+Contracts can be used in `allowedTypes` and `restrictedTypes` to allow or restrict all content types that extend a specific contract:
+
+```ts
+const PublishableContract = contract({
+  key: 'Publishable',
+  displayName: 'Publishable Content',
+  properties: {
+    publishDate: { type: 'dateTime' },
+    author: { type: 'string' },
+  },
+});
+
+const ArticleContentType = contentType({
+  key: 'Article',
+  baseType: '_page',
+  extends: PublishableContract,
+  properties: { body: { type: 'richText' } },
+});
+
+const NewsContentType = contentType({
+  key: 'News',
+  baseType: '_page',
+  extends: PublishableContract,
+  properties: { headline: { type: 'string' } },
+});
+
+const FeedPageContentType = contentType({
+  key: 'FeedPage',
+  baseType: '_page',
+  properties: {
+    featuredItems: {
+      type: 'array',
+      items: {
+        type: 'content',
+        allowedTypes: [PublishableContract], // Allows Article AND News (both extend PublishableContract)
+      },
+      displayName: 'Featured Items',
+    },
+  },
+});
+```
+
+This is particularly useful when you want to allow multiple content types that share common characteristics without listing each type individually.
+
 ## Step 2. Sync content types to the CMS
 
-After defining your content types, sync them to the CMS by running the following command:
+After defining your content types and contracts, sync them to the CMS by running the following command:
 
 ```sh
 npx @optimizely/cms-cli@latest config push optimizely.config.mjs

--- a/docs/3-modelling.md
+++ b/docs/3-modelling.md
@@ -343,6 +343,27 @@ const ArticleContentType = contentType({
       type: 'richText',
       displayName: 'Article Body',
     },
+     metaTitle: {
+      type: 'string',
+      displayName: 'Meta Title',
+      description: 'SEO title for search engines',
+      maxLength: 60,
+      group: 'seo',
+    },
+    metaDescription: {
+      type: 'string',
+      displayName: 'Meta Description',
+      description: 'SEO description for search engines',
+      maxLength: 160,
+      group: 'seo',
+    },
+    ogImage: {
+      type: 'contentReference',
+      allowedTypes: ['_image'],
+      displayName: 'Open Graph Image',
+      description: 'Image for social media sharing',
+      group: 'seo',
+    },
   },
 });
 ```
@@ -381,6 +402,37 @@ const ProductPageContentType = contentType({
     price: {
       type: 'float',
       displayName: 'Price',
+    },
+     metaTitle: {
+      type: 'string',
+      displayName: 'Meta Title',
+      description: 'SEO title for search engines',
+      maxLength: 60,
+      group: 'seo',
+    },
+    metaDescription: {
+      type: 'string',
+      displayName: 'Meta Description',
+      description: 'SEO description for search engines',
+      maxLength: 160,
+      group: 'seo',
+    },
+    ogImage: {
+      type: 'contentReference',
+      allowedTypes: ['_image'],
+      displayName: 'Open Graph Image',
+      description: 'Image for social media sharing',
+      group: 'seo',
+    },
+    analyticsId: {
+      type: 'string',
+      displayName: 'Analytics ID',
+      group: 'tracking',
+    },
+    trackingEnabled: {
+      type: 'boolean',
+      displayName: 'Enable Tracking',
+      group: 'tracking',
     },
   },
 });

--- a/docs/3-modelling.md
+++ b/docs/3-modelling.md
@@ -342,28 +342,7 @@ const ArticleContentType = contentType({
     body: {
       type: 'richText',
       displayName: 'Article Body',
-    },
-     metaTitle: {
-      type: 'string',
-      displayName: 'Meta Title',
-      description: 'SEO title for search engines',
-      maxLength: 60,
-      group: 'seo',
-    },
-    metaDescription: {
-      type: 'string',
-      displayName: 'Meta Description',
-      description: 'SEO description for search engines',
-      maxLength: 160,
-      group: 'seo',
-    },
-    ogImage: {
-      type: 'contentReference',
-      allowedTypes: ['_image'],
-      displayName: 'Open Graph Image',
-      description: 'Image for social media sharing',
-      group: 'seo',
-    },
+    }
   },
 });
 ```
@@ -402,37 +381,6 @@ const ProductPageContentType = contentType({
     price: {
       type: 'float',
       displayName: 'Price',
-    },
-     metaTitle: {
-      type: 'string',
-      displayName: 'Meta Title',
-      description: 'SEO title for search engines',
-      maxLength: 60,
-      group: 'seo',
-    },
-    metaDescription: {
-      type: 'string',
-      displayName: 'Meta Description',
-      description: 'SEO description for search engines',
-      maxLength: 160,
-      group: 'seo',
-    },
-    ogImage: {
-      type: 'contentReference',
-      allowedTypes: ['_image'],
-      displayName: 'Open Graph Image',
-      description: 'Image for social media sharing',
-      group: 'seo',
-    },
-    analyticsId: {
-      type: 'string',
-      displayName: 'Analytics ID',
-      group: 'tracking',
-    },
-    trackingEnabled: {
-      type: 'boolean',
-      displayName: 'Enable Tracking',
-      group: 'tracking',
     },
   },
 });

--- a/packages/optimizely-cms-cli/src/commands/config/push.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/push.ts
@@ -10,6 +10,7 @@ import { mapContentToManifest } from '../../mapper/contentToPackage.js';
 import { pathToFileURL } from 'node:url';
 import { constants } from 'node:fs';
 import { translateErrorMessage } from '../../utils/errors.js';
+import { contractToManifest } from '../../utils/mapping.js';
 
 export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
   static override args = {
@@ -72,14 +73,17 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
     //the pattern is relative to the config file
     const configPathDirectory = pathToFileURL(path.dirname(configFilePath)).href;
 
-    // extracts metadata(contentTypes, displayTemplates) from the component paths
-    const { contentTypes, displayTemplates } = await findMetaData(componentPaths, configPathDirectory);
+    // extracts metadata(contentTypes, displayTemplates, contracts) from the component paths
+    const { contentTypes, displayTemplates, contracts } = await findMetaData(componentPaths, configPathDirectory);
 
     // Validate and normalize property groups
     const normalizedPropertyGroups = propertyGroups ? normalizePropertyGroups(propertyGroups) : [];
 
+    // Convert contracts to manifest shape
+    const manifestContracts = contracts.map(contractToManifest);
+
     const metaData = {
-      contentTypes: mapContentToManifest(contentTypes),
+      contentTypes: mapContentToManifest(contentTypes).concat(manifestContracts),
       displayTemplates,
       propertyGroups: normalizedPropertyGroups,
     };

--- a/packages/optimizely-cms-cli/src/commands/config/push.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/push.ts
@@ -25,10 +25,12 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
       description: 'do not send anything to the server',
     }),
     force: Flags.boolean({
-      description: 'Force updates the content type even though the changes might result in data loss.',
+      description:
+        'Force updates the content type even though the changes might result in data loss.',
     }),
   };
-  static override description = 'Push content type definitions to the CMS from a configuration file';
+  static override description =
+    'Push content type definitions to the CMS from a configuration file';
   static override examples = [
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> ./custom-config.mjs',
@@ -74,7 +76,10 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
     const configPathDirectory = pathToFileURL(path.dirname(configFilePath)).href;
 
     // extracts metadata(contentTypes, displayTemplates, contracts) from the component paths
-    const { contentTypes, displayTemplates, contracts } = await findMetaData(componentPaths, configPathDirectory);
+    const { contentTypes, displayTemplates, contracts } = await findMetaData(
+      componentPaths,
+      configPathDirectory,
+    );
 
     // Validate and normalize property groups
     const normalizedPropertyGroups = propertyGroups ? normalizePropertyGroups(propertyGroups) : [];
@@ -134,7 +139,9 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
       if (response.error.status === 404) {
         spinner.fail(chalk.red('Feature Not Active'));
         console.error(
-          chalk.red('The requested feature "preview3_packages_enabled" is not enabled in your environment.'),
+          chalk.red(
+            'The requested feature "preview3_packages_enabled" is not enabled in your environment.',
+          ),
         );
         console.error(
           chalk.dim(
@@ -153,7 +160,7 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
         }
         if (response.error.errors?.length) {
           for (const [index, err] of response.error.errors.entries()) {
-            console.error((`  - ERROR ${index + 1}`));
+            console.error(`  - ERROR ${index + 1}`);
             console.error(chalk.dim(`      [DETAIL] ${err.detail}`));
             console.error(chalk.dim(`      [FIELD]  ${err.field}\n`));
           }
@@ -188,3 +195,4 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
     }
   }
 }
+

--- a/packages/optimizely-cms-cli/src/mapper/contentToPackage.ts
+++ b/packages/optimizely-cms-cli/src/mapper/contentToPackage.ts
@@ -2,6 +2,15 @@ import { AnyContentType } from '../service/utils.js';
 import { transformProperties, validateContentTypeKey, parseChildContentType } from '../utils/mapping.js';
 import chalk from 'chalk';
 
+function convertExtendsToContracts(contentType: AnyContentType): string[] | undefined {
+  if (!contentType.extends) return undefined;
+  
+  const extendsArr = Array.isArray(contentType.extends) ? contentType.extends : [contentType.extends];
+  if (extendsArr.length === 0) return undefined;
+
+  return extendsArr.map(contract => contract.key);
+}
+
 /**
  * Transforms a content type object to a manifest format.
  * Validates the content type key and formats its properties.
@@ -15,10 +24,12 @@ function transformContentType(contentType: AnyContentType, allowedKeys?: Set<str
   const { key, properties = {} } = contentType;
   const parsedContentType = parseChildContentType(contentType, allowedKeys);
   const formattedProperties = transformProperties(properties, key);
+  const contracts = convertExtendsToContracts(contentType);
 
   return {
     ...parsedContentType,
     properties: formattedProperties,
+    ...(contracts ? { contracts } : {})
   };
 }
 

--- a/packages/optimizely-cms-cli/src/mapper/contentToPackage.ts
+++ b/packages/optimizely-cms-cli/src/mapper/contentToPackage.ts
@@ -1,11 +1,15 @@
 import { AnyContentType } from '../service/utils.js';
-import { transformProperties, validateContentTypeKey, parseChildContentType } from '../utils/mapping.js';
+import {
+  transformProperties,
+  validateContentTypeKey,
+  parseChildContentType,
+} from '../utils/mapping.js';
 import chalk from 'chalk';
 
 function convertExtendsToContracts(contentType: AnyContentType): string[] | undefined {
   if (!contentType.extends) return undefined;
-  
-  const extendsArr = Array.isArray(contentType.extends) ? contentType.extends : [contentType.extends];
+  const extendsArr =
+    Array.isArray(contentType.extends) ? contentType.extends : [contentType.extends];
   if (extendsArr.length === 0) return undefined;
 
   return extendsArr.map(contract => contract.key);
@@ -22,14 +26,15 @@ function transformContentType(contentType: AnyContentType, allowedKeys?: Set<str
   validateContentTypeKey(contentType.key);
 
   const { key, properties = {} } = contentType;
-  const parsedContentType = parseChildContentType(contentType, allowedKeys);
+  // Parse the content type, excluding 'extends' from the content type
+  const { extends: _, ...parsedContentType } = parseChildContentType(contentType, allowedKeys);
   const formattedProperties = transformProperties(properties, key);
   const contracts = convertExtendsToContracts(contentType);
 
   return {
     ...parsedContentType,
     properties: formattedProperties,
-    ...(contracts ? { contracts } : {})
+    ...(contracts ? { contracts } : {}),
   };
 }
 
@@ -67,3 +72,4 @@ export function mapContentToManifest(contentTypes: AnyContentType[]): any[] {
   const allowedKeys = new Set(deduplicatedContentTypes.map(ct => ct.key));
   return deduplicatedContentTypes.map(ct => transformContentType(ct, allowedKeys));
 }
+

--- a/packages/optimizely-cms-cli/src/service/utils.ts
+++ b/packages/optimizely-cms-cli/src/service/utils.ts
@@ -9,6 +9,7 @@ import {
   DisplayTemplates,
   isDisplayTemplate,
   PropertyGroupType,
+  isContract,
 } from '@optimizely/cms-sdk';
 import chalk from 'chalk';
 import * as path from 'node:path';
@@ -51,6 +52,10 @@ function cleanType(obj: any) {
   if (obj !== null && '__type' in obj) delete obj.__type;
 }
 
+function cleanContract(obj: any) {
+  if (obj !== null && '__type' in obj) delete obj.__type;
+}
+
 function cleanDisplayTemplate(obj: any) {
   if (obj !== null) {
     if ('__type' in obj) delete obj.__type;
@@ -59,16 +64,18 @@ function cleanDisplayTemplate(obj: any) {
 }
 
 /**
- * Extract all `ContentType` and `DisplayTemplate` present in any property in `obj`
+ * Extract all relevant metadata present in an object
  *
- * Returns cleaned ('__type' removed) objects.
+ * Returns data arrays by type.
  */
 export function extractMetaData(obj: unknown): {
   contentTypeData: AnyContentType[];
   displayTemplateData: DisplayTemplate[];
+  contractData: ContentTypes.Contract[];
 } {
   let contentTypeData: AnyContentType[] = [];
   let displayTemplateData: DisplayTemplate[] = [];
+  let contractData: ContentTypes.Contract[] = [];
 
   if (typeof obj === 'object' && obj !== null) {
     for (const value of Object.values(obj)) {
@@ -78,6 +85,9 @@ export function extractMetaData(obj: unknown): {
       } else if (isDisplayTemplate(value)) {
         cleanDisplayTemplate(value);
         displayTemplateData.push(value);
+      } else if (isContract(value)) {
+        cleanContract(value);
+        contractData.push(value);
       }
     }
   }
@@ -85,6 +95,7 @@ export function extractMetaData(obj: unknown): {
   return {
     contentTypeData,
     displayTemplateData,
+    contractData,
   };
 }
 
@@ -113,13 +124,14 @@ async function compileAndImport(inputName: string, cwdUrl: string, outDir: strin
   }
 }
 
-/** Finds metadata (contentTypes, displayTemplates) in the given paths */
+/** Finds metadata (contentTypes, displayTemplates, contracts) in the given paths */
 export async function findMetaData(
   componentPaths: string[],
   cwd: string,
 ): Promise<{
   contentTypes: AnyContentType[];
   displayTemplates: DisplayTemplate[];
+  contracts: ContentTypes.Contract[];
 }> {
   const tmpDir = await mkdtemp(path.join(tmpdir(), 'optimizely-cli-'));
 
@@ -156,11 +168,12 @@ export async function findMetaData(
   const result2 = {
     contentTypes: [] as AnyContentType[],
     displayTemplates: [] as DisplayTemplate[],
+    contracts: [] as ContentTypes.Contract[],
   };
 
   for (const file of allFiles) {
     const loaded = await compileAndImport(file, cwd, tmpDir);
-    const { contentTypeData, displayTemplateData } = extractMetaData(loaded);
+    const { contentTypeData, displayTemplateData, contractData } = extractMetaData(loaded);
 
     for (const c of contentTypeData) {
       printFilesContents('Content Type', file, c);
@@ -170,6 +183,11 @@ export async function findMetaData(
     for (const d of displayTemplateData) {
       printFilesContents('Display Template', file, d);
       result2.displayTemplates.push(d);
+    }
+
+    for (const contract of contractData) {
+      printFilesContents('Contract', file, contract);
+      result2.contracts.push(contract);
     }
   }
 

--- a/packages/optimizely-cms-cli/src/service/utils.ts
+++ b/packages/optimizely-cms-cli/src/service/utils.ts
@@ -48,15 +48,11 @@ export type FoundContentType = {
 export type ContentTypeMeta = Pick<FoundContentType, 'contentType' | 'path'>;
 export type DisplayTemplateMeta = Pick<FoundContentType, 'displayTemplates' | 'path'>;
 
+/**
+ * @param obj - The object from which to remove the __type and tag properties
+ * @returns void (the function modifies the object in place)
+ */
 function cleanType(obj: any) {
-  if (obj !== null && '__type' in obj) delete obj.__type;
-}
-
-function cleanContract(obj: any) {
-  if (obj !== null && '__type' in obj) delete obj.__type;
-}
-
-function cleanDisplayTemplate(obj: any) {
   if (obj !== null) {
     if ('__type' in obj) delete obj.__type;
     if ('tag' in obj) delete obj.tag;
@@ -83,10 +79,10 @@ export function extractMetaData(obj: unknown): {
         cleanType(value);
         contentTypeData.push(value);
       } else if (isDisplayTemplate(value)) {
-        cleanDisplayTemplate(value);
+        cleanType(value);
         displayTemplateData.push(value);
       } else if (isContract(value)) {
-        cleanContract(value);
+        cleanType(value);
         contractData.push(value);
       }
     }
@@ -295,3 +291,4 @@ export function extractKeyName(input: PermittedTypes, parentKey: string): string
     : input.key
   );
 }
+

--- a/packages/optimizely-cms-cli/src/utils/generate.ts
+++ b/packages/optimizely-cms-cli/src/utils/generate.ts
@@ -69,6 +69,10 @@ const generateContentTypeArguments = (content: ContentType) => {
       : undefined,
     mayContainTypes:
       !isContract(content) && content.mayContainTypes?.length ? content.mayContainTypes : undefined,
+    extends:
+      content.contracts?.length ?
+        content.contracts.map(c => (isImportable(c) ? markForImport(c) : c))
+      : undefined,
     properties: generateProperties(content),
   };
   return JSON.stringify(fnArguments, null, 2);
@@ -77,9 +81,11 @@ const generateContentTypeArguments = (content: ContentType) => {
 const generateDisplayTemplateArguments = (content: DisplayTemplate) => {
   const fnArguments = {
     key: content.key,
+    isDefault: content.isDefault,
     displayName: content.displayName,
-    contentType: content.contentType,
-    nodeType: content.nodeType,
+    contentType: 'contentType' in content ? content.contentType : undefined,
+    nodeType: 'nodeType' in content ? content.nodeType : undefined,
+    baseType: 'baseType' in content ? content.baseType : undefined,
     settings: content.settings,
   };
   return JSON.stringify(fnArguments, null, 2);
@@ -203,7 +209,7 @@ const commonKeyContents = ['Contract', 'CT', 'ContentType', 'DT', 'DisplayTempla
 
 const markedImportRegex = /\<\|(.+?)\|\>/g;
 
-const propertiesThatCanHoldImports = ['contentType', 'allowedTypes', 'restrictedTypes'];
+const propertiesThatCanHoldImports = ['contentType', 'allowedTypes', 'restrictedTypes', 'extends'];
 
 const skipPropertyConditions: Record<string, (it: any) => boolean> = {
   isLocalized: (it: any) => it === false,
@@ -212,4 +218,8 @@ const skipPropertyConditions: Record<string, (it: any) => boolean> = {
   allowedTypes: (it: any) => it?.length === 0,
   restrictedTypes: (it: any) => it?.length === 0,
   mayContainTypes: (it: any) => it?.length === 0,
+  extends: (it: any) => it?.length === 0,
+  contentType: (it: any) => it === undefined,
+  nodeType: (it: any) => it === undefined,
+  baseType: (it: any) => it === undefined,
 };

--- a/packages/optimizely-cms-cli/src/utils/manifest.ts
+++ b/packages/optimizely-cms-cli/src/utils/manifest.ts
@@ -46,8 +46,9 @@ export type ContentType = Omit<
   mayContainTypes?: string[];
   properties?: Record<string, ContentTypeProperties.All>;
   compositionBehaviors?: ('sectionEnabled' | 'elementEnabled')[];
-  isContract: boolean;
   baseType?: string;
+  contracts?: string[];
+  isContract?: boolean;
 };
 
 /**

--- a/packages/optimizely-cms-cli/src/utils/manifest.ts
+++ b/packages/optimizely-cms-cli/src/utils/manifest.ts
@@ -11,6 +11,7 @@ import { ContentTypes, Properties, DisplayTemplates } from '@optimizely/cms-sdk'
 export type Manifest = {
   contentTypes: ContentType[];
   displayTemplates?: DisplayTemplate[];
+  contracts?: ManifestContract[];
 };
 
 export type JSONContent = ContentType | DisplayTemplate;
@@ -36,16 +37,28 @@ export type DisplayTemplate = Partial<
  * - mayContainTypes uses string[] instead of ContentType<T>[] | string[]
  * - properties uses our adapted ContentTypeProperties.All
  * - compositionBehaviors added as optional (only on ComponentContentType in SDK, but needed at API level)
+ * - contracts replaces extends and uses only the key of the contract
  */
 export type ContentType = Omit<
   ContentTypes.AnyContentType,
-  'mayContainTypes' | 'properties' | 'baseType'
+  'mayContainTypes' | 'properties' | 'extends'
 > & {
   mayContainTypes?: string[];
   properties?: Record<string, ContentTypeProperties.All>;
   compositionBehaviors?: ('sectionEnabled' | 'elementEnabled')[];
   isContract: boolean;
   baseType?: string;
+};
+
+/**
+ * Contract (API format)
+ * Based on SDK's AnyContentType but adapted for API serialization:
+ * - mayContainTypes uses string[] instead of ContentType<T>[] | string[]
+ * - properties uses our adapted ContentTypeProperties.All
+ * - compositionBehaviors added as optional (only on ComponentContentType in SDK, but needed at API level)
+ */
+export type ManifestContract = Omit<ContentTypes.Contract, '__type' | 'properties'> & {
+  properties: Record<string, ContentTypeProperties.All>;
 };
 
 /**
@@ -147,3 +160,4 @@ export namespace ContentTypeProperties {
 
   export type All = Array | NonArray;
 }
+

--- a/packages/optimizely-cms-cli/src/utils/manifest.ts
+++ b/packages/optimizely-cms-cli/src/utils/manifest.ts
@@ -52,10 +52,8 @@ export type ContentType = Omit<
 
 /**
  * Contract (API format)
- * Based on SDK's AnyContentType but adapted for API serialization:
- * - mayContainTypes uses string[] instead of ContentType<T>[] | string[]
- * - properties uses our adapted ContentTypeProperties.All
- * - compositionBehaviors added as optional (only on ComponentContentType in SDK, but needed at API level)
+ * - Omits __type
+ * - Swaps properties to use ContentTypeProperties.All over AnyProperty
  */
 export type ManifestContract = Omit<ContentTypes.Contract, '__type' | 'properties'> & {
   properties: Record<string, ContentTypeProperties.All>;

--- a/packages/optimizely-cms-cli/src/utils/mapping.ts
+++ b/packages/optimizely-cms-cli/src/utils/mapping.ts
@@ -1,6 +1,7 @@
-import { ContentType } from './manifest.js';
+import { ContentType, ManifestContract } from './manifest.js';
 import { extractKeyName } from '../service/utils.js';
 import { isKeyInvalid } from './validate.js';
+import { ContentTypes } from '@optimizely/cms-sdk';
 
 /**
  * Normalizes the `mayContainTypes` field of a content type object.
@@ -274,4 +275,18 @@ export function filterSystemContentTypes(contentTypes: ContentType[]): ContentTy
       !['BlankExperience', 'BlankSection'].includes(ct.key),
   );
 }
+
+/**
+ * Converts contract into manifest shape
+ */
+export const contractToManifest = ({
+  key,
+  displayName,
+  properties,
+}: ContentTypes.Contract): ManifestContract => ({
+  key,
+  displayName,
+  isContract: true,
+  properties: transformProperties(properties, key),
+});
 

--- a/packages/optimizely-cms-cli/src/utils/mapping.ts
+++ b/packages/optimizely-cms-cli/src/utils/mapping.ts
@@ -274,3 +274,4 @@ export function filterSystemContentTypes(contentTypes: ContentType[]): ContentTy
       !['BlankExperience', 'BlankSection'].includes(ct.key),
   );
 }
+

--- a/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
@@ -20,7 +20,7 @@ describe('Fragment generation for single contract', () => {
     initContentTypeRegistry([TestContract]);
 
     const result = await createFragment('TestContract');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -64,7 +64,7 @@ describe('Fragment generation of contracts used in pages', () => {
     initContentTypeRegistry([TestContract, TestPage]);
 
     const result = await createFragment('TestPage');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -97,7 +97,7 @@ describe('Fragment generation of contracts used in pages', () => {
     initContentTypeRegistry([TestContract, TestPage]);
 
     const result = await createFragment('TestPage');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -173,7 +173,7 @@ describe('Fragment generation of contracts with experiences', () => {
     initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, TestExperience]);
 
     const result = await createFragment('TestExperience');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -251,7 +251,7 @@ describe('Fragment generation of contracts with experiences', () => {
     initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, TestExperience]);
 
     const result = await createFragment('TestExperience');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -349,10 +349,16 @@ describe('Fragment generation of contracts with experiences', () => {
       },
     });
 
-    initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, ContentTypeC, TestExperience]);
+    initContentTypeRegistry([
+      TestContract,
+      ContentTypeA,
+      ContentTypeB,
+      ContentTypeC,
+      TestExperience,
+    ]);
 
     const result = await createFragment('TestExperience');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -369,5 +375,4 @@ describe('Fragment generation of contracts with experiences', () => {
     `);
   });
 });
-
 

--- a/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { contract, contentType, initContentTypeRegistry } from '../../model/index.js';
+import { createFragment } from '../createQuery.js';
+
+describe('contracts', () => {
+  it('should create Categorizable contract with Category and Tags properties', async () => {
+    const Categorizable = contract({
+      key: 'categorizable',
+      displayName: 'Categorizable',
+      properties: {
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    initContentTypeRegistry([Categorizable]);
+
+    const result = await createFragment('categorizable');
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
+        "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
+        "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
+        "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
+        "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
+        "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
+        "fragment categorizable on categorizable { __typename categorizable__Category:Category categorizable__Tags:Tags ..._IContent }",
+      ]
+    `);
+  });
+
+  it('should create experience with array of content and content property with allowedTypes', async () => {
+    const Categorizable = contract({
+      key: 'categorizable',
+      displayName: 'Categorizable',
+      properties: {
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const ContentTypeA = contentType({
+      baseType: '_component',
+      key: 'ContentTypeA',
+      extends: [Categorizable],
+      displayName: 'ContentTypeA',
+      properties: {
+        headingA: {
+          type: 'string',
+        },
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const ContentTypeB = contentType({
+      baseType: '_component',
+      key: 'ContentTypeB',
+      extends: [Categorizable],
+      displayName: 'ContentTypeB',
+      properties: {
+        headingB: {
+          type: 'string',
+        },
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const TestExperience = contentType({
+      baseType: '_experience',
+      key: 'TestExperience',
+      displayName: 'Test Experience',
+      properties: {
+        sections: {
+          type: 'array',
+          items: {
+            type: 'content',
+            allowedTypes: [Categorizable],
+          },
+        },
+        mainContent: {
+          type: 'content',
+          allowedTypes: [Categorizable],
+        },
+      },
+    });
+
+    initContentTypeRegistry([Categorizable, ContentTypeA, ContentTypeB, TestExperience]);
+
+    const result = await createFragment('TestExperience');
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
+        "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
+        "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
+        "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
+        "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
+        "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
+        "fragment categorizable on categorizable { __typename categorizable__Category:Category categorizable__Tags:Tags ..._IContent }",
+        "fragment _IExperience on _IExperience { composition {...ICompositionNode }}",
+        "fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }",
+        "fragment _IComponent on _IComponent { __typename  }",
+        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...categorizable } TestExperience__mainContent:mainContent { __typename ...categorizable } ..._IContent ..._IExperience }",
+      ]
+    `);
+  });
+
+  it('Test when section enabled or element enabled is used in the contentTypes ContentTypeA & ContentTypeB that extends contract ', async () => {
+    const Categorizable = contract({
+      key: 'categorizable',
+      displayName: 'Categorizable',
+      properties: {
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const ContentTypeA = contentType({
+      baseType: '_component',
+      key: 'ContentTypeA',
+      extends: [Categorizable],
+      displayName: 'ContentTypeA',
+      compositionBehaviors: ['elementEnabled'],
+      properties: {
+        headingA: {
+          type: 'string',
+        },
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const ContentTypeB = contentType({
+      baseType: '_component',
+      key: 'ContentTypeB',
+      extends: [Categorizable],
+      displayName: 'ContentTypeB',
+      compositionBehaviors: ['sectionEnabled'],
+      properties: {
+        headingB: {
+          type: 'string',
+        },
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const TestExperience = contentType({
+      baseType: '_experience',
+      key: 'TestExperience',
+      displayName: 'Test Experience',
+      properties: {
+        sections: {
+          type: 'array',
+          items: {
+            type: 'content',
+            allowedTypes: [Categorizable],
+          },
+        },
+        mainContent: {
+          type: 'content',
+          allowedTypes: [Categorizable],
+        },
+      },
+    });
+
+    initContentTypeRegistry([Categorizable, ContentTypeA, ContentTypeB, TestExperience]);
+
+    const result = await createFragment('TestExperience');
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
+        "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
+        "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
+        "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
+        "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
+        "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
+        "fragment categorizable on categorizable { __typename categorizable__Category:Category categorizable__Tags:Tags ..._IContent }",
+        "fragment _IExperience on _IExperience { composition {...ICompositionNode }}",
+        "fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }",
+        "fragment ContentTypeA on ContentTypeA { __typename ContentTypeA__Category:Category ContentTypeA__Tags:Tags ContentTypeA__headingA:headingA ..._IContent }",
+        "fragment ContentTypeB on ContentTypeB { __typename ContentTypeB__Category:Category ContentTypeB__Tags:Tags ContentTypeB__headingB:headingB ..._IContent }",
+        "fragment _IComponent on _IComponent { __typename ...ContentTypeA ...ContentTypeB }",
+        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...categorizable } TestExperience__mainContent:mainContent { __typename ...categorizable } ..._IContent ..._IExperience }",
+      ]
+    `);
+  });
+
+  it('should create experience with array of content and content property with restrictedTypes', async () => {
+    const Categorizable = contract({
+      key: 'categorizable',
+      displayName: 'Categorizable',
+      properties: {
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const ContentTypeA = contentType({
+      baseType: '_component',
+      key: 'ContentTypeA',
+      extends: [Categorizable],
+      displayName: 'ContentTypeA',
+      properties: {
+        headingA: {
+          type: 'string',
+        },
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const ContentTypeB = contentType({
+      baseType: '_component',
+      key: 'ContentTypeB',
+      extends: [Categorizable],
+      displayName: 'ContentTypeB',
+      properties: {
+        headingB: {
+          type: 'string',
+        },
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const TestExperience = contentType({
+      baseType: '_experience',
+      key: 'TestExperience',
+      displayName: 'Test Experience',
+      properties: {
+        sections: {
+          type: 'array',
+          items: {
+            type: 'content',
+
+            restrictedTypes: [Categorizable],
+          },
+        },
+        mainContent: {
+          type: 'content',
+          restrictedTypes: [Categorizable],
+        },
+      },
+    });
+
+    initContentTypeRegistry([Categorizable, ContentTypeA, ContentTypeB, TestExperience]);
+
+    const result = await createFragment('TestExperience');
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
+        "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
+        "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
+        "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
+        "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
+        "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
+        "fragment ContentTypeA on ContentTypeA { __typename ContentTypeA__Category:Category ContentTypeA__Tags:Tags ContentTypeA__headingA:headingA ..._IContent }",
+        "fragment ContentTypeB on ContentTypeB { __typename ContentTypeB__Category:Category ContentTypeB__Tags:Tags ContentTypeB__headingB:headingB ..._IContent }",
+        "fragment _IExperience on _IExperience { composition {...ICompositionNode }}",
+        "fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }",
+        "fragment _IComponent on _IComponent { __typename  }",
+        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...ContentTypeA ...ContentTypeB ...TestExperience } TestExperience__mainContent:mainContent { __typename ...ContentTypeA ...ContentTypeB ...TestExperience } ..._IContent ..._IExperience }",
+      ]
+    `);
+  });
+});
+

--- a/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { contract, contentType, initContentTypeRegistry } from '../../model/index.js';
 import { createFragment } from '../createQuery.js';
 
-describe('contracts', () => {
+describe('Fragment generation for single contract', () => {
   it('should create TestContract with Category and Tags properties', async () => {
     const TestContract = contract({
       key: 'TestContract',
@@ -32,34 +32,29 @@ describe('contracts', () => {
       ]
     `);
   });
+});
 
-  it('should create fragments for page with allowedTypes that accepts contracts', async () => {
-    const TestContract = contract({
-      key: 'TestContract',
-      displayName: 'Test Contract',
-      properties: {
-        Category: {
-          type: 'string',
-        },
-        Tags: {
-          type: 'string',
-        },
+describe('Fragment generation of contracts used in pages', () => {
+  const TestContract = contract({
+    key: 'TestContract',
+    displayName: 'Test Contract',
+    properties: {
+      Category: {
+        type: 'string',
       },
-    });
+      Tags: {
+        type: 'string',
+      },
+    },
+  });
 
+  it('should create fragments for page with inline content areas having allowedTypes that accepts contracts', async () => {
     const TestPage = contentType({
       baseType: '_page',
       key: 'TestPage',
       displayName: 'Test Page',
       properties: {
-        sections: {
-          type: 'array',
-          items: {
-            type: 'content',
-            allowedTypes: [TestContract],
-          },
-        },
-        mainContent: {
+        main: {
           type: 'content',
           allowedTypes: [TestContract],
         },
@@ -78,12 +73,47 @@ describe('contracts', () => {
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
         "fragment TestContract on ITestContract { __typename TestContract__Category:Category TestContract__Tags:Tags ..._IContent }",
-        "fragment TestPage on TestPage { __typename TestPage__sections:sections { __typename ...TestContract } TestPage__mainContent:mainContent { __typename ...TestContract } ..._IContent }",
+        "fragment TestPage on TestPage { __typename TestPage__main:main { __typename ...TestContract } ..._IContent }",
       ]
     `);
   });
 
-  it('should create experience with allowedTypes contract when extending components have no composition behaviors', async () => {
+  it('should create fragments for page with content areas having allowedTypes that accepts contracts', async () => {
+    const TestPage = contentType({
+      baseType: '_page',
+      key: 'TestPage',
+      displayName: 'Test Page',
+      properties: {
+        areas: {
+          type: 'array',
+          items: {
+            type: 'content',
+            allowedTypes: [TestContract],
+          },
+        },
+      },
+    });
+
+    initContentTypeRegistry([TestContract, TestPage]);
+
+    const result = await createFragment('TestPage');
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
+        "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
+        "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
+        "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
+        "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
+        "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
+        "fragment TestContract on ITestContract { __typename TestContract__Category:Category TestContract__Tags:Tags ..._IContent }",
+        "fragment TestPage on TestPage { __typename TestPage__areas:areas { __typename ...TestContract } ..._IContent }",
+      ]
+    `);
+  });
+});
+
+describe('Fragment generation of contracts with experiences', () => {
+  it('should create fragments for experience with contracts, components without composition behaviors', async () => {
     const TestContract = contract({
       key: 'TestContract',
       displayName: 'Test Contract',
@@ -137,19 +167,7 @@ describe('contracts', () => {
       baseType: '_experience',
       key: 'TestExperience',
       displayName: 'Test Experience',
-      properties: {
-        sections: {
-          type: 'array',
-          items: {
-            type: 'content',
-            allowedTypes: [TestContract],
-          },
-        },
-        mainContent: {
-          type: 'content',
-          allowedTypes: [TestContract],
-        },
-      },
+      properties: {},
     });
 
     initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, TestExperience]);
@@ -163,16 +181,15 @@ describe('contracts', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment TestContract on ITestContract { __typename TestContract__Category:Category TestContract__Tags:Tags ..._IContent }",
         "fragment _IExperience on _IExperience { composition {...ICompositionNode }}",
         "fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }",
         "fragment _IComponent on _IComponent { __typename  }",
-        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...TestContract } TestExperience__mainContent:mainContent { __typename ...TestContract } ..._IContent ..._IExperience }",
+        "fragment TestExperience on TestExperience { __typename ..._IContent ..._IExperience }",
       ]
     `);
   });
 
-  it('should create experience with allowedTypes contract when extending components have composition behaviors', async () => {
+  it('should create fragments for experience with contracts, components with composition behaviors', async () => {
     const TestContract = contract({
       key: 'TestContract',
       displayName: 'Test Contract',
@@ -228,19 +245,7 @@ describe('contracts', () => {
       baseType: '_experience',
       key: 'TestExperience',
       displayName: 'Test Experience',
-      properties: {
-        sections: {
-          type: 'array',
-          items: {
-            type: 'content',
-            allowedTypes: [TestContract],
-          },
-        },
-        mainContent: {
-          type: 'content',
-          allowedTypes: [TestContract],
-        },
-      },
+      properties: {},
     });
 
     initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, TestExperience]);
@@ -254,18 +259,17 @@ describe('contracts', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment TestContract on ITestContract { __typename TestContract__Category:Category TestContract__Tags:Tags ..._IContent }",
         "fragment _IExperience on _IExperience { composition {...ICompositionNode }}",
         "fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }",
         "fragment ContentTypeA on ContentTypeA { __typename ContentTypeA__Category:Category ContentTypeA__Tags:Tags ContentTypeA__headingA:headingA ..._IContent }",
         "fragment ContentTypeB on ContentTypeB { __typename ContentTypeB__Category:Category ContentTypeB__Tags:Tags ContentTypeB__headingB:headingB ..._IContent }",
         "fragment _IComponent on _IComponent { __typename ...ContentTypeA ...ContentTypeB }",
-        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...TestContract } TestExperience__mainContent:mainContent { __typename ...TestContract } ..._IContent ..._IExperience }",
+        "fragment TestExperience on TestExperience { __typename ..._IContent ..._IExperience }",
       ]
     `);
   });
 
-  it('should create experience with array of content and content property with restrictedTypes', async () => {
+  it('should create fragments for experience with content areas that do not have contracts', async () => {
     const TestContract = contract({
       key: 'testContract',
       displayName: 'Test Contract',
@@ -315,26 +319,37 @@ describe('contracts', () => {
       },
     });
 
+    const ContentTypeC = contentType({
+      baseType: '_component',
+      key: 'ContentTypeC',
+      extends: [TestContract],
+      displayName: 'ContentTypeC',
+      properties: {
+        headingC: {
+          type: 'string',
+        },
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
     const TestExperience = contentType({
       baseType: '_experience',
       key: 'TestExperience',
       displayName: 'Test Experience',
       properties: {
-        sections: {
-          type: 'array',
-          items: {
-            type: 'content',
-            restrictedTypes: [TestContract],
-          },
-        },
-        mainContent: {
+        main_area: {
           type: 'content',
-          restrictedTypes: [TestContract],
+          allowedTypes: [ContentTypeC],
         },
       },
     });
 
-    initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, TestExperience]);
+    initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, ContentTypeC, TestExperience]);
 
     const result = await createFragment('TestExperience');
     expect(result).toMatchInlineSnapshot(`
@@ -345,12 +360,11 @@ describe('contracts', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment ContentTypeA on ContentTypeA { __typename ContentTypeA__Category:Category ContentTypeA__Tags:Tags ContentTypeA__headingA:headingA ..._IContent }",
-        "fragment ContentTypeB on ContentTypeB { __typename ContentTypeB__Category:Category ContentTypeB__Tags:Tags ContentTypeB__headingB:headingB ..._IContent }",
+        "fragment ContentTypeC on ContentTypeC { __typename ContentTypeC__Category:Category ContentTypeC__Tags:Tags ContentTypeC__headingC:headingC ..._IContent }",
         "fragment _IExperience on _IExperience { composition {...ICompositionNode }}",
         "fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }",
         "fragment _IComponent on _IComponent { __typename  }",
-        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...ContentTypeA ...ContentTypeB ...TestExperience } TestExperience__mainContent:mainContent { __typename ...ContentTypeA ...ContentTypeB ...TestExperience } ..._IContent ..._IExperience }",
+        "fragment TestExperience on TestExperience { __typename TestExperience__main_area:main_area { __typename ...ContentTypeC } ..._IContent ..._IExperience }",
       ]
     `);
   });

--- a/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { contract, contentType, initContentTypeRegistry } from '../../model/index.js';
 import { createFragment } from '../createQuery.js';
 
 describe('contracts', () => {
-  it('should create Categorizable contract with Category and Tags properties', async () => {
-    const Categorizable = contract({
-      key: 'categorizable',
-      displayName: 'Categorizable',
+  it('should create TestContract with Category and Tags properties', async () => {
+    const TestContract = contract({
+      key: 'TestContract',
+      displayName: 'Test Contract',
       properties: {
         Category: {
           type: 'string',
@@ -17,9 +17,9 @@ describe('contracts', () => {
       },
     });
 
-    initContentTypeRegistry([Categorizable]);
+    initContentTypeRegistry([TestContract]);
 
-    const result = await createFragment('categorizable');
+    const result = await createFragment('TestContract');
     expect(result).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
@@ -28,15 +28,65 @@ describe('contracts', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment categorizable on categorizable { __typename categorizable__Category:Category categorizable__Tags:Tags ..._IContent }",
+        "fragment TestContract on ITestContract { __typename TestContract__Category:Category TestContract__Tags:Tags ..._IContent }",
       ]
     `);
   });
 
-  it('should create experience with array of content and content property with allowedTypes', async () => {
-    const Categorizable = contract({
-      key: 'categorizable',
-      displayName: 'Categorizable',
+  it('should create fragments for page with allowedTypes that accepts contracts', async () => {
+    const TestContract = contract({
+      key: 'TestContract',
+      displayName: 'Test Contract',
+      properties: {
+        Category: {
+          type: 'string',
+        },
+        Tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const TestPage = contentType({
+      baseType: '_page',
+      key: 'TestPage',
+      displayName: 'Test Page',
+      properties: {
+        sections: {
+          type: 'array',
+          items: {
+            type: 'content',
+            allowedTypes: [TestContract],
+          },
+        },
+        mainContent: {
+          type: 'content',
+          allowedTypes: [TestContract],
+        },
+      },
+    });
+
+    initContentTypeRegistry([TestContract, TestPage]);
+
+    const result = await createFragment('TestPage');
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
+        "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
+        "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
+        "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
+        "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
+        "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
+        "fragment TestContract on ITestContract { __typename TestContract__Category:Category TestContract__Tags:Tags ..._IContent }",
+        "fragment TestPage on TestPage { __typename TestPage__sections:sections { __typename ...TestContract } TestPage__mainContent:mainContent { __typename ...TestContract } ..._IContent }",
+      ]
+    `);
+  });
+
+  it('should create experience with allowedTypes contract when extending components have no composition behaviors', async () => {
+    const TestContract = contract({
+      key: 'TestContract',
+      displayName: 'Test Contract',
       properties: {
         Category: {
           type: 'string',
@@ -50,7 +100,7 @@ describe('contracts', () => {
     const ContentTypeA = contentType({
       baseType: '_component',
       key: 'ContentTypeA',
-      extends: [Categorizable],
+      extends: [TestContract],
       displayName: 'ContentTypeA',
       properties: {
         headingA: {
@@ -68,7 +118,7 @@ describe('contracts', () => {
     const ContentTypeB = contentType({
       baseType: '_component',
       key: 'ContentTypeB',
-      extends: [Categorizable],
+      extends: [TestContract],
       displayName: 'ContentTypeB',
       properties: {
         headingB: {
@@ -92,17 +142,17 @@ describe('contracts', () => {
           type: 'array',
           items: {
             type: 'content',
-            allowedTypes: [Categorizable],
+            allowedTypes: [TestContract],
           },
         },
         mainContent: {
           type: 'content',
-          allowedTypes: [Categorizable],
+          allowedTypes: [TestContract],
         },
       },
     });
 
-    initContentTypeRegistry([Categorizable, ContentTypeA, ContentTypeB, TestExperience]);
+    initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, TestExperience]);
 
     const result = await createFragment('TestExperience');
     expect(result).toMatchInlineSnapshot(`
@@ -113,19 +163,19 @@ describe('contracts', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment categorizable on categorizable { __typename categorizable__Category:Category categorizable__Tags:Tags ..._IContent }",
+        "fragment TestContract on ITestContract { __typename TestContract__Category:Category TestContract__Tags:Tags ..._IContent }",
         "fragment _IExperience on _IExperience { composition {...ICompositionNode }}",
         "fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }",
         "fragment _IComponent on _IComponent { __typename  }",
-        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...categorizable } TestExperience__mainContent:mainContent { __typename ...categorizable } ..._IContent ..._IExperience }",
+        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...TestContract } TestExperience__mainContent:mainContent { __typename ...TestContract } ..._IContent ..._IExperience }",
       ]
     `);
   });
 
-  it('Test when section enabled or element enabled is used in the contentTypes ContentTypeA & ContentTypeB that extends contract ', async () => {
-    const Categorizable = contract({
-      key: 'categorizable',
-      displayName: 'Categorizable',
+  it('should create experience with allowedTypes contract when extending components have composition behaviors', async () => {
+    const TestContract = contract({
+      key: 'TestContract',
+      displayName: 'Test Contract',
       properties: {
         Category: {
           type: 'string',
@@ -139,7 +189,7 @@ describe('contracts', () => {
     const ContentTypeA = contentType({
       baseType: '_component',
       key: 'ContentTypeA',
-      extends: [Categorizable],
+      extends: [TestContract],
       displayName: 'ContentTypeA',
       compositionBehaviors: ['elementEnabled'],
       properties: {
@@ -158,7 +208,7 @@ describe('contracts', () => {
     const ContentTypeB = contentType({
       baseType: '_component',
       key: 'ContentTypeB',
-      extends: [Categorizable],
+      extends: [TestContract],
       displayName: 'ContentTypeB',
       compositionBehaviors: ['sectionEnabled'],
       properties: {
@@ -183,17 +233,17 @@ describe('contracts', () => {
           type: 'array',
           items: {
             type: 'content',
-            allowedTypes: [Categorizable],
+            allowedTypes: [TestContract],
           },
         },
         mainContent: {
           type: 'content',
-          allowedTypes: [Categorizable],
+          allowedTypes: [TestContract],
         },
       },
     });
 
-    initContentTypeRegistry([Categorizable, ContentTypeA, ContentTypeB, TestExperience]);
+    initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, TestExperience]);
 
     const result = await createFragment('TestExperience');
     expect(result).toMatchInlineSnapshot(`
@@ -204,21 +254,21 @@ describe('contracts', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment categorizable on categorizable { __typename categorizable__Category:Category categorizable__Tags:Tags ..._IContent }",
+        "fragment TestContract on ITestContract { __typename TestContract__Category:Category TestContract__Tags:Tags ..._IContent }",
         "fragment _IExperience on _IExperience { composition {...ICompositionNode }}",
         "fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }",
         "fragment ContentTypeA on ContentTypeA { __typename ContentTypeA__Category:Category ContentTypeA__Tags:Tags ContentTypeA__headingA:headingA ..._IContent }",
         "fragment ContentTypeB on ContentTypeB { __typename ContentTypeB__Category:Category ContentTypeB__Tags:Tags ContentTypeB__headingB:headingB ..._IContent }",
         "fragment _IComponent on _IComponent { __typename ...ContentTypeA ...ContentTypeB }",
-        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...categorizable } TestExperience__mainContent:mainContent { __typename ...categorizable } ..._IContent ..._IExperience }",
+        "fragment TestExperience on TestExperience { __typename TestExperience__sections:sections { __typename ...TestContract } TestExperience__mainContent:mainContent { __typename ...TestContract } ..._IContent ..._IExperience }",
       ]
     `);
   });
 
   it('should create experience with array of content and content property with restrictedTypes', async () => {
-    const Categorizable = contract({
-      key: 'categorizable',
-      displayName: 'Categorizable',
+    const TestContract = contract({
+      key: 'testContract',
+      displayName: 'Test Contract',
       properties: {
         Category: {
           type: 'string',
@@ -232,7 +282,7 @@ describe('contracts', () => {
     const ContentTypeA = contentType({
       baseType: '_component',
       key: 'ContentTypeA',
-      extends: [Categorizable],
+      extends: [TestContract],
       displayName: 'ContentTypeA',
       properties: {
         headingA: {
@@ -250,7 +300,7 @@ describe('contracts', () => {
     const ContentTypeB = contentType({
       baseType: '_component',
       key: 'ContentTypeB',
-      extends: [Categorizable],
+      extends: [TestContract],
       displayName: 'ContentTypeB',
       properties: {
         headingB: {
@@ -274,18 +324,17 @@ describe('contracts', () => {
           type: 'array',
           items: {
             type: 'content',
-
-            restrictedTypes: [Categorizable],
+            restrictedTypes: [TestContract],
           },
         },
         mainContent: {
           type: 'content',
-          restrictedTypes: [Categorizable],
+          restrictedTypes: [TestContract],
         },
       },
     });
 
-    initContentTypeRegistry([Categorizable, ContentTypeA, ContentTypeB, TestExperience]);
+    initContentTypeRegistry([TestContract, ContentTypeA, ContentTypeB, TestExperience]);
 
     const result = await createFragment('TestExperience');
     expect(result).toMatchInlineSnapshot(`
@@ -306,4 +355,5 @@ describe('contracts', () => {
     `);
   });
 });
+
 

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -10,6 +10,7 @@ import {
   getContentType,
   getAllContentTypes,
   getContentTypeByBaseType,
+  RegistryEntry,
 } from '../model/contentTypeRegistry.js';
 import {
   getKeyName,
@@ -21,8 +22,8 @@ import {
 } from '../util/baseTypeUtil.js';
 import { checkTypeConstraintIssues } from '../util/fragmentConstraintChecks.js';
 import { GraphMissingContentTypeError, GraphQueryGenerationError } from './error.js';
-import { contentType, isContract } from '../model/index.js';
 import { toArray } from '../util/general.js';
+import { isContract } from '../model/index.js';
 
 /**
  * Options for controlling GraphQL fragment generation behavior.
@@ -63,7 +64,7 @@ let allContentTypes: AnyContentType[] = [];
  * Avoids repeated calls to the content registry.
  * @returns An array of all contentType definitions.
  */
-function getCachedContentTypes(): AnyContentType[] {
+function getCachedContentTypes(): RegistryEntry[] {
   if (allContentTypes.length === 0) {
     allContentTypes = getAllContentTypes();
   }
@@ -81,7 +82,7 @@ function refreshCache() {
  * @param ct - The content type to check.
  * @returns True if all properties are disabled, false otherwise.
  */
-function allPropertiesAreDisabled(ct: AnyContentType | Contract): boolean {
+function allPropertiesAreDisabled(ct: RegistryEntry): boolean {
   if (!ct || !ct.properties) return false;
   let hasProperties = false;
   for (const k in ct.properties) {
@@ -247,7 +248,7 @@ function createExperienceFragments(
 
   const experienceNodes = getCachedContentTypes()
     .filter(c => {
-      if (c.baseType === '_component') {
+      if ('baseType' in c && c.baseType === '_component') {
         return 'compositionBehaviors' in c && (c.compositionBehaviors?.length ?? 0) > 0;
       }
       return false;
@@ -315,7 +316,7 @@ export function createFragment(
     fields.push(...f);
     extraFragments.push(...e);
   } else {
-    // User-defined content type
+    // User-defined content type or contract
     const ct = getContentType(contentTypeName);
 
     //TODO: delete me
@@ -353,7 +354,7 @@ export function createFragment(
       fields.push(...baseFragments.fields);
     }
 
-    if (ct.baseType === '_experience') {
+    if ('baseType' in ct && ct.baseType === '_experience') {
       fields.push('..._IExperience');
       const experienceResult = createExperienceFragments(visited, {
         damEnabled,
@@ -506,18 +507,14 @@ function resolveAllowedTypes(
   allowed: PermittedTypes[] | undefined,
   restricted: PermittedTypes[] | undefined,
 ): (PermittedTypes | AnyContentType)[] {
-  const contentTypes = getAllContentTypes();
-  const allowedFixed = fixSpecialImports(contentTypes, allowed);
-  const restrictedFixed = fixSpecialImports(contentTypes, restricted);
-
   const skip = new Set<string>();
   const seen = new Set<string>();
   const result: (PermittedTypes | AnyContentType)[] = [];
-  const baseline = allowedFixed?.length ? allowedFixed : getCachedContentTypes();
+  const baseline = allowed?.length ? allowed : getCachedContentTypes();
 
   // If a CMS base media type ("_image", "_media" …) is restricted,
   // we must also ban every user defined media type that shares the same media type
-  restrictedFixed?.forEach(r => {
+  restricted?.forEach(r => {
     const key = getKeyName(r);
     skip.add(key);
     if (isBaseType(key)) {
@@ -540,7 +537,7 @@ function resolveAllowedTypes(
     const key = getKeyName(entry);
 
     // If this entry is a base media type inject all matching custom media‑types *before* it.
-    if (allowedFixed?.length && isBaseType(key)) {
+    if (allowed?.length && isBaseType(key)) {
       getContentTypeByBaseType(key).forEach(add);
     }
 

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -17,7 +17,6 @@ import {
   buildBaseTypeFragments,
   isBaseType,
   toBaseTypeFragmentKey,
-  getFragmentName,
   CONTENT_URL_FRAGMENT,
   DAM_ASSET_FRAGMENTS,
 } from '../util/baseTypeUtil.js';
@@ -58,7 +57,7 @@ type FragmentResult = {
   includesDamAssetsFragments: boolean;
 };
 
-let allContentTypes: AnyContentType[] = [];
+let allContentTypes: RegistryEntry[] = [];
 
 /**
  * Retrieves and caches all content type definitions.
@@ -269,7 +268,7 @@ function createExperienceFragments(
       { fragments: [], includesDamAssetsFragments: false } as FragmentResult,
     );
 
-  const nodeNames = experienceNodes.map(n => `...${getFragmentName(n)}`).join(' ');
+  const nodeNames = experienceNodes.map(n => `...${n}`).join(' ');
   const componentFragment = `fragment _IComponent on _IComponent { __typename ${nodeNames} }`;
 
   return {
@@ -369,7 +368,7 @@ export function createFragment(
 
   // Convert base type key to GraphQL fragment format
   // eg: "_image" -> "_Image", "testContract" contract -> "ITestContract"
-  const parsedFragmentName = toBaseTypeFragmentKey(typeName);
+  const parsedFragmentName = toBaseTypeFragmentKey(contentTypeName);
 
   // Add DAM asset fragments if contentReference with DAM was used
   if (includesDamAssetsFragments) {

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -17,6 +17,7 @@ import {
   buildBaseTypeFragments,
   isBaseType,
   toBaseTypeFragmentKey,
+  getFragmentName,
   CONTENT_URL_FRAGMENT,
   DAM_ASSET_FRAGMENTS,
 } from '../util/baseTypeUtil.js';
@@ -268,7 +269,7 @@ function createExperienceFragments(
       { fragments: [], includesDamAssetsFragments: false } as FragmentResult,
     );
 
-  const nodeNames = experienceNodes.map(n => `...${n}`).join(' ');
+  const nodeNames = experienceNodes.map(n => `...${getFragmentName(n)}`).join(' ');
   const componentFragment = `fragment _IComponent on _IComponent { __typename ${nodeNames} }`;
 
   return {
@@ -300,6 +301,17 @@ export function createFragment(
   }
 
   const { damEnabled = false, maxFragmentThreshold = 100, includeBaseFragments = true } = options;
+  let ct: RegistryEntry | undefined;
+
+  // Determine content type early to know if it's a contract
+  if (!isBaseType(contentTypeName)) {
+    ct = getContentType(contentTypeName);
+    if (!ct) {
+      throw new GraphMissingContentTypeError(contentTypeName);
+    }
+  }
+
+  // Fragment name for definition (no "I" prefix)
   const fragmentName = `${contentTypeName}${suffix}`;
   if (visited.has(fragmentName)) return { fragments: [], includesDamAssetsFragments: false }; // cyclic ref guard
   // Refresh registry cache only on the *root* call (avoids redundant reads)
@@ -316,20 +328,9 @@ export function createFragment(
     fields.push(...f);
     extraFragments.push(...e);
   } else {
-    // User-defined content type or contract
-    const ct = getContentType(contentTypeName);
-
-    //TODO: delete me
-    if (ct && ct.key === 'GQLContractPage') {
-      console.log(JSON.stringify(ct, null, 2));
-    }
-
-    if (!ct) {
-      throw new GraphMissingContentTypeError(contentTypeName);
-    }
-
+    // User-defined content type or contract (ct already retrieved above)
     // Gather fields for every property
-    for (const [propKey, prop] of Object.entries(ct.properties ?? {})) {
+    for (const [propKey, prop] of Object.entries(ct!.properties ?? {})) {
       // Skip properties with indexingType "disabled"
       if (prop.indexingType === 'disabled') {
         continue;
@@ -338,7 +339,7 @@ export function createFragment(
         fields: f,
         extraFragments: e,
         includesDamAssetsFragments: propHasRef,
-      } = convertProperty(propKey, prop, contentTypeName, suffix, visited, {
+      } = convertProperty(propKey, prop, fragmentName, '', visited, {
         damEnabled,
         maxFragmentThreshold,
       });
@@ -354,7 +355,7 @@ export function createFragment(
       fields.push(...baseFragments.fields);
     }
 
-    if ('baseType' in ct && ct.baseType === '_experience') {
+    if ('baseType' in ct! && ct!.baseType === '_experience') {
       fields.push('..._IExperience');
       const experienceResult = createExperienceFragments(visited, {
         damEnabled,
@@ -367,8 +368,8 @@ export function createFragment(
   }
 
   // Convert base type key to GraphQL fragment format
-  // eg: "_image" -> "_Image"
-  const parsedFragmentName = toBaseTypeFragmentKey(fragmentName);
+  // eg: "_image" -> "_Image", "testContract" contract -> "ITestContract"
+  const parsedFragmentName = toBaseTypeFragmentKey(typeName);
 
   // Add DAM asset fragments if contentReference with DAM was used
   if (includesDamAssetsFragments) {

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -1,6 +1,7 @@
 import { AnyProperty } from '../model/properties.js';
 import {
   AnyContentType,
+  ContentType,
   Contract,
   MAIN_BASE_TYPES,
   PermittedTypes,
@@ -20,6 +21,8 @@ import {
 } from '../util/baseTypeUtil.js';
 import { checkTypeConstraintIssues } from '../util/fragmentConstraintChecks.js';
 import { GraphMissingContentTypeError, GraphQueryGenerationError } from './error.js';
+import { contentType, isContract } from '../model/index.js';
+import { toArray } from '../util/general.js';
 
 /**
  * Options for controlling GraphQL fragment generation behavior.
@@ -314,6 +317,12 @@ export function createFragment(
   } else {
     // User-defined content type
     const ct = getContentType(contentTypeName);
+
+    //TODO: delete me
+    if (ct && ct.key === 'GQLContractPage') {
+      console.log(JSON.stringify(ct, null, 2));
+    }
+
     if (!ct) {
       throw new GraphMissingContentTypeError(contentTypeName);
     }
@@ -461,6 +470,32 @@ export type ItemsResponse<T> = {
   };
 };
 
+function findContractExtenders(
+  contentType: PermittedTypes,
+  contentTypes: AnyContentType[],
+): ContentType<AnyContentType>[] {
+  if (typeof contentType === 'object' && contentType !== null && 'key' in contentType) {
+    const key = contentType.key;
+    return contentTypes.filter(
+      contentType =>
+        contentType.extends && toArray(contentType.extends).some(contract => contract.key === key),
+    ) as ContentType<AnyContentType>[];
+  }
+  return [];
+}
+
+function fixSpecialImports(
+  contentTypes: AnyContentType[],
+  items: PermittedTypes[] | undefined = [],
+): PermittedTypes[] | undefined {
+  if (!items || items.length === 0) return items;
+  return items
+    .map(contentType =>
+      !isContract(contentType) ? contentType : findContractExtenders(contentType, contentTypes),
+    )
+    .flat();
+}
+
 /**
  * Resolves the set of allowed content types for a property, excluding restricted and recursive entries.
  * @param allowed - Explicit allow list of types.
@@ -471,14 +506,18 @@ function resolveAllowedTypes(
   allowed: PermittedTypes[] | undefined,
   restricted: PermittedTypes[] | undefined,
 ): (PermittedTypes | AnyContentType)[] {
+  const contentTypes = getAllContentTypes();
+  const allowedFixed = fixSpecialImports(contentTypes, allowed);
+  const restrictedFixed = fixSpecialImports(contentTypes, restricted);
+
   const skip = new Set<string>();
   const seen = new Set<string>();
   const result: (PermittedTypes | AnyContentType)[] = [];
-  const baseline = allowed?.length ? allowed : getCachedContentTypes();
+  const baseline = allowedFixed?.length ? allowedFixed : getCachedContentTypes();
 
   // If a CMS base media type ("_image", "_media" …) is restricted,
   // we must also ban every user defined media type that shares the same media type
-  restricted?.forEach(r => {
+  restrictedFixed?.forEach(r => {
     const key = getKeyName(r);
     skip.add(key);
     if (isBaseType(key)) {
@@ -501,7 +540,7 @@ function resolveAllowedTypes(
     const key = getKeyName(entry);
 
     // If this entry is a base media type inject all matching custom media‑types *before* it.
-    if (allowed?.length && isBaseType(key)) {
+    if (allowedFixed?.length && isBaseType(key)) {
       getContentTypeByBaseType(key).forEach(add);
     }
 

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -1,5 +1,10 @@
 import { AnyProperty } from '../model/properties.js';
-import { AnyContentType, MAIN_BASE_TYPES, PermittedTypes } from '../model/contentTypes.js';
+import {
+  AnyContentType,
+  Contract,
+  MAIN_BASE_TYPES,
+  PermittedTypes,
+} from '../model/contentTypes.js';
 import {
   getContentType,
   getAllContentTypes,
@@ -73,7 +78,7 @@ function refreshCache() {
  * @param ct - The content type to check.
  * @returns True if all properties are disabled, false otherwise.
  */
-function allPropertiesAreDisabled(ct: AnyContentType): boolean {
+function allPropertiesAreDisabled(ct: AnyContentType | Contract): boolean {
   if (!ct || !ct.properties) return false;
   let hasProperties = false;
   for (const k in ct.properties) {
@@ -505,3 +510,4 @@ function resolveAllowedTypes(
 
   return result;
 }
+

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -1,11 +1,5 @@
 import { AnyProperty } from '../model/properties.js';
-import {
-  AnyContentType,
-  ContentType,
-  Contract,
-  MAIN_BASE_TYPES,
-  PermittedTypes,
-} from '../model/contentTypes.js';
+import { AnyContentType, MAIN_BASE_TYPES, PermittedTypes } from '../model/contentTypes.js';
 import {
   getContentType,
   getAllContentTypes,
@@ -22,7 +16,6 @@ import {
 } from '../util/baseTypeUtil.js';
 import { checkTypeConstraintIssues } from '../util/fragmentConstraintChecks.js';
 import { GraphMissingContentTypeError, GraphQueryGenerationError } from './error.js';
-import { toArray } from '../util/general.js';
 import { isContract } from '../model/index.js';
 
 /**
@@ -278,6 +271,30 @@ function createExperienceFragments(
 }
 
 /**
+ * Determines the parsed fragment name based on content type characteristics.
+ * @param contentTypeName - The original content type name/key.
+ * @param fragmentName - The fragment name (may include suffix).
+ * @param ct - The content type registry entry (undefined for base types).
+ * @returns The parsed fragment name for GraphQL fragment definition.
+ */
+function getParsedFragmentName(
+  contentTypeName: string,
+  fragmentName: string,
+  ct: RegistryEntry | undefined,
+): string {
+  if (isBaseType(contentTypeName)) {
+    // Base types: apply capitalization (e.g., "_image" -> "_Image")
+    return toBaseTypeFragmentKey(contentTypeName);
+  } else if (ct && isContract(ct)) {
+    // Contracts: add "I" prefix to fragment name (includes suffix)
+    return `I${fragmentName}`;
+  } else {
+    // Regular content types or component properties: use fragment name as-is (includes suffix)
+    return fragmentName;
+  }
+}
+
+/**
  * Builds a GraphQL fragment for the requested content-type **and** returns every nested fragment it depends on.
  * @param contentTypeName Name/key of the content-type to expand.
  * @param visited Set of fragment names already on the stack.
@@ -368,7 +385,7 @@ export function createFragment(
 
   // Convert base type key to GraphQL fragment format
   // eg: "_image" -> "_Image", "testContract" contract -> "ITestContract"
-  const parsedFragmentName = toBaseTypeFragmentKey(contentTypeName);
+  const parsedFragmentName = getParsedFragmentName(contentTypeName, fragmentName, ct);
 
   // Add DAM asset fragments if contentReference with DAM was used
   if (includesDamAssetsFragments) {
@@ -471,32 +488,6 @@ export type ItemsResponse<T> = {
   };
 };
 
-function findContractExtenders(
-  contentType: PermittedTypes,
-  contentTypes: AnyContentType[],
-): ContentType<AnyContentType>[] {
-  if (typeof contentType === 'object' && contentType !== null && 'key' in contentType) {
-    const key = contentType.key;
-    return contentTypes.filter(
-      contentType =>
-        contentType.extends && toArray(contentType.extends).some(contract => contract.key === key),
-    ) as ContentType<AnyContentType>[];
-  }
-  return [];
-}
-
-function fixSpecialImports(
-  contentTypes: AnyContentType[],
-  items: PermittedTypes[] | undefined = [],
-): PermittedTypes[] | undefined {
-  if (!items || items.length === 0) return items;
-  return items
-    .map(contentType =>
-      !isContract(contentType) ? contentType : findContractExtenders(contentType, contentTypes),
-    )
-    .flat();
-}
-
 /**
  * Resolves the set of allowed content types for a property, excluding restricted and recursive entries.
  * @param allowed - Explicit allow list of types.
@@ -546,4 +537,5 @@ function resolveAllowedTypes(
 
   return result;
 }
+
 

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -230,25 +230,40 @@ type GetLinksResponse = {
  */
 export function removeTypePrefix(obj: any): any {
   if (Array.isArray(obj)) {
-    return obj.map(e => removeTypePrefix(e));
+    return obj.map(removeTypePrefix);
   }
 
   if (typeof obj === 'object' && obj !== null) {
     const obj2: Record<string, any> = {};
     if ('__typename' in obj && typeof obj.__typename === 'string') {
-      // Object has a GraphQL type, check for and remove aliased field prefixes
-      const prefix = obj.__typename + '__';
+      // Get all types from metadata (includes contracts/interfaces)
+      const types = obj._metadata?.types || [obj.__typename];
 
-      // Copy all properties, remove the typename from prefix
       for (const k in obj) {
-        if (k.startsWith(prefix)) {
-          obj2[k.slice(prefix.length)] = removeTypePrefix(obj[k]);
-        } else {
+        // skip prefix check for keys without '__'
+        if (!k.includes('__')) {
+          obj2[k] = removeTypePrefix(obj[k]);
+          continue;
+        }
+
+        // Check each type prefix and strip first match
+        let stripped = false;
+        for (let i = 0; i < types.length; i++) {
+          const prefix = types[i] + '__';
+          if (k.startsWith(prefix)) {
+            obj2[k.slice(prefix.length)] = removeTypePrefix(obj[k]);
+            stripped = true;
+            break;
+          }
+        }
+
+        // No prefix matched, copy as-is
+        if (!stripped) {
           obj2[k] = removeTypePrefix(obj[k]);
         }
       }
     } else {
-      // Traverse recursively
+      // Traverse recursively for objects without __typename
       for (const k in obj) {
         obj2[k] = removeTypePrefix(obj[k]);
       }

--- a/packages/optimizely-cms-sdk/src/index.ts
+++ b/packages/optimizely-cms-sdk/src/index.ts
@@ -2,8 +2,10 @@
 export {
   buildConfig,
   contentType,
+  contract,
   displayTemplate,
   isContentType,
+  isContract,
   isDisplayTemplate,
   isContentTypeRegistered,
   initContentTypeRegistry,

--- a/packages/optimizely-cms-sdk/src/model/contentTypeRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/model/contentTypeRegistry.ts
@@ -1,9 +1,11 @@
-import { AnyContentType } from './contentTypes.js';
+import { AnyContentType, Contract } from './contentTypes.js';
 
-let _registry: AnyContentType[] = [];
+export type RegistryEntry = AnyContentType | Contract;
+
+let _registry: RegistryEntry[] = [];
 
 /** Initializes the content type registry */
-export function init(registry: AnyContentType[]) {
+export function init(registry: RegistryEntry[]) {
   _registry = registry;
 }
 
@@ -13,13 +15,13 @@ export function getContentType(name: string) {
 }
 
 /** Get all the content types */
-export function getAllContentTypes(): AnyContentType[] {
+export function getAllContentTypes(): RegistryEntry[] {
   return _registry;
 }
 
 /** Get the Component from a base type */
 export function getContentTypeByBaseType(name: string): AnyContentType[] {
-  return _registry.filter(c => c.baseType === name) as AnyContentType[];
+  return _registry.filter((c): c is AnyContentType => 'baseType' in c && c.baseType === name);
 }
 
 /**

--- a/packages/optimizely-cms-sdk/src/model/contentTypes.ts
+++ b/packages/optimizely-cms-sdk/src/model/contentTypes.ts
@@ -26,19 +26,33 @@ type BaseContentType = {
 };
 
 /** Represents the required values to be provided to make a Contract type */
-export type SuppliedContractValues = {
+export type SuppliedContractValues<P extends PropertiesRecord = PropertiesRecord> = {
   key: string;
   displayName: string;
-  properties: PropertiesRecord;
-}
+  properties: P;
+};
 
 type InnerContractValues = {
   isContract: true;
   __type: 'contract';
-}
+};
 
 /** Represents the Contract type in CMS */
-export type Contract = SuppliedContractValues & InnerContractValues;
+export type Contract<P extends PropertiesRecord = PropertiesRecord> = SuppliedContractValues<P> & InnerContractValues;
+
+/** Convert union to intersection type */
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
+
+/** Extract properties from contracts without distributing */
+type ExtractContractProperties<C> = C extends Contract<infer P> ? P : never;
+
+/** Type-level property merging - mirrors the runtime getMergedProps function */
+type MergedPropertiesType<T extends AnyContentType> = ('extends' extends keyof T ?
+  T['extends'] extends Array<any> ? UnionToIntersection<ExtractContractProperties<T['extends'][number]>>
+  : T['extends'] extends Contract<infer P> ? P
+  : {}
+: {}) &
+  ('properties' extends keyof T ? T['properties'] : {});
 
 /** Represents the Page type  in CMS */
 export type PageContentType = BaseContentType & {
@@ -84,7 +98,10 @@ export type AnyContentType =
   | SectionContentType
   | MediaContentType;
 
-export type ContentType<T = AnyContentType> = T & { __type: 'contentType' };
+export type ContentType<T extends AnyContentType = AnyContentType> = Omit<T, 'properties'> & {
+  properties: MergedPropertiesType<T>;
+  __type: 'contentType';
+};
 
 /** All possible content types for allowed and restricted fields */
 export type PermittedTypes = Contract | ContentType | AnyContentType['baseType'] | '_self';

--- a/packages/optimizely-cms-sdk/src/model/contentTypes.ts
+++ b/packages/optimizely-cms-sdk/src/model/contentTypes.ts
@@ -15,12 +15,30 @@ export const ALL_BASE_TYPES = [...MAIN_BASE_TYPES, ...MEDIA_BASE_TYPES, ...OTHER
 export type BaseTypes = (typeof ALL_BASE_TYPES)[number];
 export type MediaStringTypes = (typeof MEDIA_BASE_TYPES)[number];
 
+export type PropertiesRecord = Record<string, AnyProperty>;
+
 /** A "Base" content type that includes all common attributes for all content types */
 type BaseContentType = {
   key: string;
   displayName: string;
-  properties?: Record<string, AnyProperty>;
+  extends?: Contract | Array<Contract>;
+  properties?: PropertiesRecord;
 };
+
+/** Represents the required values to be provided to make a Contract type */
+export type SuppliedContractValues = {
+  key: string;
+  displayName: string;
+  properties: PropertiesRecord;
+}
+
+type InnerContractValues = {
+  isContract: true;
+  __type: 'contract';
+}
+
+/** Represents the Contract type in CMS */
+export type Contract = SuppliedContractValues & InnerContractValues;
 
 /** Represents the Page type  in CMS */
 export type PageContentType = BaseContentType & {
@@ -68,5 +86,5 @@ export type AnyContentType =
 
 export type ContentType<T = AnyContentType> = T & { __type: 'contentType' };
 
-/** All possible content type for allowed and restricted fields */
-export type PermittedTypes = ContentType | AnyContentType['baseType'] | '_self';
+/** All possible content types for allowed and restricted fields */
+export type PermittedTypes = Contract | ContentType | AnyContentType['baseType'] | '_self';

--- a/packages/optimizely-cms-sdk/src/model/displayTemplates.ts
+++ b/packages/optimizely-cms-sdk/src/model/displayTemplates.ts
@@ -1,4 +1,4 @@
-import { DisplaySettingsType, ContentProps } from '../infer.js';
+import { DisplaySettingsType } from '../infer.js';
 import { BaseTypes } from './contentTypes.js';
 
 // section node types
@@ -55,7 +55,11 @@ type BaseDisplayTemplate = {
   tag?: string; // Optional tag property to store the name of the React component
 };
 
-export type DisplayTemplateVariant = BaseDisplayTemplate & (NodeTemplate | BaseTemplate | WithContentType);
+export type DisplayTemplateVariant =
+  | BaseDisplayTemplate
+  | (BaseDisplayTemplate & NodeTemplate)
+  | (BaseDisplayTemplate & BaseTemplate)
+  | (BaseDisplayTemplate & WithContentType);
 
 export type DisplayTemplate<T = DisplayTemplateVariant> = T & {
   __type: 'displayTemplate';
@@ -81,3 +85,4 @@ export function parseDisplaySettings(
 
   return result;
 }
+

--- a/packages/optimizely-cms-sdk/src/model/index.ts
+++ b/packages/optimizely-cms-sdk/src/model/index.ts
@@ -1,39 +1,30 @@
 import { BuildConfig } from './buildConfig.js';
-import {
-  AnyContentType,
-  Contract,
-  PropertiesRecord,
-  SuppliedContractValues,
-} from './contentTypes.js';
+import { AnyContentType, ContentType, Contract, PropertiesRecord, SuppliedContractValues } from './contentTypes.js';
 import { DisplayTemplate, DisplayTemplateVariant } from './displayTemplates.js';
 
-function getMergedProps<T extends AnyContentType>(
-  options: T,
-): PropertiesRecord | undefined {
+function getMergedProps<T extends AnyContentType>(options: T): PropertiesRecord | undefined {
   if (!options.extends && !options.properties) return undefined;
 
-  const contracts = Array.isArray(options.extends)
-    ? options.extends
-    : [options.extends];
-  const mergedContractsProps = contracts
-    .reduce((acc, contract) => contract?.properties ? ({ ...acc, ...contract.properties }) : acc, {});
+  const contracts = Array.isArray(options.extends) ? options.extends : [options.extends];
+  const mergedContractsProps = contracts.reduce(
+    (acc, contract) => (contract?.properties ? { ...acc, ...contract.properties } : acc),
+    {},
+  );
   const props = options.properties;
   const merged = { ...mergedContractsProps, ...props };
 
-  if (Object.keys(merged).length) return (merged as PropertiesRecord)
-  return undefined
+  if (Object.keys(merged).length) return merged as PropertiesRecord;
+  return undefined;
 }
 
 /** Defines a Optimizely CMS content type */
-export function contentType<T extends AnyContentType>(
-  options: T,
-): T & { __type: 'contentType' } {
+export function contentType<T extends AnyContentType>(options: T): ContentType<T> {
   const properties = getMergedProps(options);
   return {
     ...options,
     ...(properties ? { properties } : {}),
     __type: 'contentType',
-  };
+  } as unknown as ContentType<T>;
 }
 
 /**
@@ -69,21 +60,17 @@ export function contentType<T extends AnyContentType>(
  * });
  * ```
  */
-export function contract(options: SuppliedContractValues): Contract {
+export function contract<P extends PropertiesRecord>(options: SuppliedContractValues<P>): Contract<P> {
   return { ...options, __type: 'contract', isContract: true };
 }
 
 /** Defines a Optimizely CMS display template */
-export function displayTemplate<T extends DisplayTemplateVariant>(
-  options: T,
-): DisplayTemplate<T> {
+export function displayTemplate<T extends DisplayTemplateVariant>(options: T): DisplayTemplate<T> {
   return { ...options, __type: 'displayTemplate' };
 }
 
 /** Defines a Optimizely CMS build configuration */
-export function buildConfig<T extends BuildConfig>(
-  options: T,
-): T & { __type: 'buildConfig' } {
+export function buildConfig<T extends BuildConfig>(options: T): T & { __type: 'buildConfig' } {
   return { ...options, __type: 'buildConfig' };
 }
 
@@ -119,8 +106,5 @@ export function isDisplayTemplate(obj: unknown): obj is DisplayTemplate {
 }
 
 export { PropertyGroupType } from './buildConfig.js';
-export {
-  init as initContentTypeRegistry,
-  isContentTypeRegistered,
-} from './contentTypeRegistry.js';
+export { init as initContentTypeRegistry, isContentTypeRegistered } from './contentTypeRegistry.js';
 export { init as initDisplayTemplateRegistry } from './displayTemplateRegistry.js';

--- a/packages/optimizely-cms-sdk/src/model/index.ts
+++ b/packages/optimizely-cms-sdk/src/model/index.ts
@@ -1,19 +1,57 @@
 import { BuildConfig } from './buildConfig.js';
-import { AnyContentType } from './contentTypes.js';
+import {
+  AnyContentType,
+  Contract,
+  PropertiesRecord,
+  SuppliedContractValues,
+} from './contentTypes.js';
 import { DisplayTemplate, DisplayTemplateVariant } from './displayTemplates.js';
 
+function getMergedProps<T extends AnyContentType>(
+  options: T,
+): PropertiesRecord | undefined {
+  if (!options.extends && !options.properties) return undefined;
+
+  const contracts = Array.isArray(options.extends)
+    ? options.extends
+    : [options.extends];
+  const mergedContractsProps = contracts
+    .reduce((acc, contract) => contract?.properties ? ({ ...acc, ...contract.properties }) : acc, {});
+  const props = options.properties;
+  const merged = { ...mergedContractsProps, ...props };
+
+  if (Object.keys(merged).length) return (merged as PropertiesRecord)
+  return undefined
+}
+
 /** Defines a Optimizely CMS content type */
-export function contentType<T extends AnyContentType>(options: T): T & { __type: 'contentType' } {
-  return { ...options, __type: 'contentType' };
+export function contentType<T extends AnyContentType>(
+  options: T,
+): T & { __type: 'contentType' } {
+  const properties = getMergedProps(options);
+  return {
+    ...options,
+    ...(properties ? { properties } : {}),
+    __type: 'contentType',
+  };
+}
+
+/** Defines a Optimizely CMS contract */
+export function contract(options: SuppliedContractValues): Contract {
+  return { ...options, __type: 'contract', isContract: true };
 }
 
 /** Defines a Optimizely CMS display template */
-export function displayTemplate<T extends DisplayTemplateVariant>(options: T): DisplayTemplate<T> {
+export function displayTemplate<T extends DisplayTemplateVariant>(
+  options: T,
+): DisplayTemplate<T> {
   return { ...options, __type: 'displayTemplate' };
 }
 
 /** Defines a Optimizely CMS build configuration */
-export function buildConfig<T extends BuildConfig>(options: T): T & { __type: 'buildConfig' } {
+export function buildConfig<T extends BuildConfig>(
+  options: T,
+): T & { __type: 'buildConfig' } {
   return { ...options, __type: 'buildConfig' };
 }
 
@@ -23,6 +61,15 @@ export function buildConfig<T extends BuildConfig>(options: T): T & { __type: 'b
 export function isContentType(obj: unknown): obj is AnyContentType {
   return (
     typeof obj === 'object' && obj !== null && '__type' in obj && (obj as any).__type === 'contentType' && 'key' in obj
+  );
+}
+
+/**
+ * Checks if `obj` is a contract.
+ */
+export function isContract(obj: unknown): obj is Contract {
+  return (
+    typeof obj === 'object' && obj !== null && '__type' in obj && (obj as any).__type === 'contract' && 'key' in obj
   );
 }
 
@@ -40,5 +87,8 @@ export function isDisplayTemplate(obj: unknown): obj is DisplayTemplate {
 }
 
 export { PropertyGroupType } from './buildConfig.js';
-export { init as initContentTypeRegistry, isContentTypeRegistered } from './contentTypeRegistry.js';
+export {
+  init as initContentTypeRegistry,
+  isContentTypeRegistered,
+} from './contentTypeRegistry.js';
 export { init as initDisplayTemplateRegistry } from './displayTemplateRegistry.js';

--- a/packages/optimizely-cms-sdk/src/model/index.ts
+++ b/packages/optimizely-cms-sdk/src/model/index.ts
@@ -36,7 +36,39 @@ export function contentType<T extends AnyContentType>(
   };
 }
 
-/** Defines a Optimizely CMS contract */
+/**
+ * Defines an Optimizely CMS contract.
+ *
+ * @param options - The contract definition
+ * @param options.key - Unique identifier for the contract
+ * @param options.displayName - Human-readable name shown in the CMS UI
+ * @param options.properties - Property definitions that will be inherited by extending content types
+ * @returns A contract object
+ *
+ * @example
+ * ```typescript
+ * const SEOContract = contract({
+ *   key: 'seo',
+ *   displayName: 'SEO Properties',
+ *   properties: {
+ *     metaTitle: { type: 'string' },
+ *     metaDescription: { type: 'string' },
+ *   }
+ * });
+ *
+ * // Content types can extend this contract
+ * const ArticleContentType = contentType({
+ *   key: 'article',
+ *   displayName: 'Article',
+ *   baseType: '_page',
+ *   extends: SEOContract,
+ *   properties: {
+ *     title: { type: 'string' },
+ *     body: { type: 'richText' }
+ *   }
+ * });
+ * ```
+ */
 export function contract(options: SuppliedContractValues): Contract {
   return { ...options, __type: 'contract', isContract: true };
 }

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -80,51 +80,64 @@ export function initReactComponentRegistry(options: InitOptions) {
   componentRegistry = new ComponentRegistry(options.resolver);
 }
 
+/** Content data from CMS */
+type OptimizelyContent = {
+  /** Content type name */
+  __typename: string;
+
+  /** Display template tag (if any) */
+  __tag?: string;
+
+  displayTemplateKey?: string | null;
+
+  /** Preview context */
+  __context?: { edit: boolean; preview_token: string };
+
+  __composition?: ExperienceCompositionNode;
+
+  /** metadata */
+  _metadata?: {
+    types?: string[];
+    displayOption?: string | null;
+  };
+};
+
 /** Props for the {@linkcode OptimizelyComponent} component */
 type OptimizelyComponentProps = {
   /** Data read from the CMS */
-  content: {
-    /** Content type name */
-    __typename: string;
-
-    /** Display template tag (if any) */
-    __tag?: string;
-
-    displayTemplateKey?: string | null;
-
-    /** Preview context */
-    __context?: { edit: boolean; preview_token: string };
-
-    __composition?: ExperienceCompositionNode;
-  };
+  content: OptimizelyContent;
 
   displaySettings?: Record<string, string | boolean>;
 };
 
 /**
- * Attempts to get component from contract types fallback.
- * If content implements a contract but no component is registered for the contract itself,
- * tries to find a component using the first type in content._metadata.types array.
+ * Gets display template key from content, checking multiple sources.
  */
-function getComponentFromContractFallback(
-  content: Record<string, any>,
+function getDisplayTemplateKey(content: OptimizelyContent): string | null | undefined {
+  return content._metadata?.displayOption ?? content.__composition?.displayTemplateKey ?? content.displayTemplateKey;
+}
+
+/**
+ * Finds component by trying each type in _metadata.types array, falling back to __typename.
+ * Returns both the matched component and the typename that resolved.
+ */
+function findComponent(
+  content: OptimizelyContent,
   options: { tag?: string },
-): React.ComponentType<any> | undefined {
-  if (
-    typeof content === 'object' &&
-    content !== null &&
-    '_metadata' in content &&
-    content._metadata &&
-    typeof content._metadata === 'object' &&
-    content._metadata !== null &&
-    'types' in content._metadata
-  ) {
-    const types = content._metadata.types;
-    if (Array.isArray(types) && types.length > 0) {
-      return componentRegistry?.getComponent(types[0], options);
+): { component: React.ComponentType<any> | undefined; typename: string | undefined } {
+  // Try _metadata.types array first
+  const types = content._metadata?.types;
+  if (Array.isArray(types)) {
+    for (const typename of types) {
+      const component = componentRegistry.getComponent(typename, options);
+      if (component) return { component, typename };
     }
   }
-  return undefined;
+
+  // Fallback to __typename
+  const typename = content.__typename;
+  const component = typename ? componentRegistry.getComponent(typename, options) : undefined;
+  return { component, typename };
 }
 
 export async function OptimizelyComponent({ content, displaySettings, ...props }: OptimizelyComponentProps) {
@@ -135,20 +148,15 @@ export async function OptimizelyComponent({ content, displaySettings, ...props }
   if (!componentRegistry) {
     throw new OptimizelyReactError('You should call `initReactComponentRegistry` first');
   }
-  const dtKey = content.__composition?.displayTemplateKey ?? content.displayTemplateKey;
+
+  const dtKey = getDisplayTemplateKey(content);
   const tag = content.__tag ?? getDisplayTemplateTag(dtKey);
-
-  let Component = componentRegistry.getComponent(content.__typename, { tag });
-
-  // If component not found, try contract types fallback
-  if (!Component) {
-    Component = getComponentFromContractFallback(content, { tag });
-  }
+  const { component: Component, typename } = findComponent(content, { tag });
 
   if (!Component) {
     return (
       <FallbackComponent>
-        No component found for content type <b>{content.__typename}</b>
+        No component found for content type <b>{typename}</b>
       </FallbackComponent>
     );
   }
@@ -377,3 +385,5 @@ export function getPreviewUtils(content: OptimizelyComponentProps['content']) {
     },
   };
 }
+
+

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -109,38 +109,37 @@ type OptimizelyComponentProps = {
 
   displaySettings?: Record<string, string | boolean>;
 
-  /** Manual variant override - maps content type to display variant */
-  variant?: Record<string, string>;
+  /** Manual tag override for component lookup */
+  tag?: string;
 };
 
 /**
  * Gets display template key from content, checking multiple sources.
  */
 function getDisplayTemplateKey(content: OptimizelyContent): string | null | undefined {
-  return content._metadata?.displayOption ?? content.__composition?.displayTemplateKey ?? content.displayTemplateKey;
+  return (
+    content._metadata?.displayOption ??
+    content.__composition?.displayTemplateKey ??
+    content.displayTemplateKey
+  );
 }
 
 /**
  * Resolves the tag to use for component lookup.
- * Checks variant override first, then falls back to content.__tag or display template tag.
+ * Checks tag override first, then falls back to content.__tag or display template tag.
  */
-function resolveTag(content: OptimizelyContent, variant: Record<string, string> | undefined): string | undefined {
-  const dtKey = getDisplayTemplateKey(content);
-  let tag = content.__tag ?? getDisplayTemplateTag(dtKey);
-
-  // Check variant override - try metadata.types first, then __typename
-  if (variant) {
-    const types = content._metadata?.types ?? [];
-    const allTypes = [...types, content.__typename];
-    for (const typename of allTypes) {
-      if (typename && variant[typename]) {
-        tag = variant[typename];
-        break;
-      }
-    }
+function resolveTag(
+  content: OptimizelyContent,
+  componentTag: string | undefined,
+): string | undefined {
+  //  tag override priority for tag provided by caller (e.g. OptimizelyComponent's `tag` prop)
+  if (componentTag) {
+    return componentTag;
   }
 
-  return tag;
+  // Fall back to content tag or display template tag or displayOption
+  const dtKey = getDisplayTemplateKey(content);
+  return content.__tag ?? getDisplayTemplateTag(dtKey);
 }
 
 /**
@@ -166,17 +165,24 @@ function findComponent(
   return { component, typename };
 }
 
-export async function OptimizelyComponent({ content, displaySettings, variant, ...props }: OptimizelyComponentProps) {
+export async function OptimizelyComponent({
+  content,
+  displaySettings,
+  tag,
+  ...props
+}: OptimizelyComponentProps) {
   if (!content) {
-    throw new OptimizelyReactError('OptimizelyComponent requires a valid content prop. Received null or undefined.');
+    throw new OptimizelyReactError(
+      'OptimizelyComponent requires a valid content prop. Received null or undefined.',
+    );
   }
 
   if (!componentRegistry) {
     throw new OptimizelyReactError('You should call `initReactComponentRegistry` first');
   }
 
-  const tag = resolveTag(content, variant);
-  const { component: Component, typename } = findComponent(content, { tag });
+  const resolvedTag = resolveTag(content, tag);
+  const { component: Component, typename } = findComponent(content, { tag: resolvedTag });
 
   if (!Component) {
     return (
@@ -410,4 +416,5 @@ export function getPreviewUtils(content: OptimizelyComponentProps['content']) {
     },
   };
 }
+
 

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -108,6 +108,9 @@ type OptimizelyComponentProps = {
   content: OptimizelyContent;
 
   displaySettings?: Record<string, string | boolean>;
+
+  /** Manual variant override - maps content type to display variant */
+  variant?: Record<string, string>;
 };
 
 /**
@@ -115,6 +118,29 @@ type OptimizelyComponentProps = {
  */
 function getDisplayTemplateKey(content: OptimizelyContent): string | null | undefined {
   return content._metadata?.displayOption ?? content.__composition?.displayTemplateKey ?? content.displayTemplateKey;
+}
+
+/**
+ * Resolves the tag to use for component lookup.
+ * Checks variant override first, then falls back to content.__tag or display template tag.
+ */
+function resolveTag(content: OptimizelyContent, variant: Record<string, string> | undefined): string | undefined {
+  const dtKey = getDisplayTemplateKey(content);
+  let tag = content.__tag ?? getDisplayTemplateTag(dtKey);
+
+  // Check variant override - try metadata.types first, then __typename
+  if (variant) {
+    const types = content._metadata?.types ?? [];
+    const allTypes = [...types, content.__typename];
+    for (const typename of allTypes) {
+      if (typename && variant[typename]) {
+        tag = variant[typename];
+        break;
+      }
+    }
+  }
+
+  return tag;
 }
 
 /**
@@ -140,7 +166,7 @@ function findComponent(
   return { component, typename };
 }
 
-export async function OptimizelyComponent({ content, displaySettings, ...props }: OptimizelyComponentProps) {
+export async function OptimizelyComponent({ content, displaySettings, variant, ...props }: OptimizelyComponentProps) {
   if (!content) {
     throw new OptimizelyReactError('OptimizelyComponent requires a valid content prop. Received null or undefined.');
   }
@@ -149,8 +175,7 @@ export async function OptimizelyComponent({ content, displaySettings, ...props }
     throw new OptimizelyReactError('You should call `initReactComponentRegistry` first');
   }
 
-  const dtKey = getDisplayTemplateKey(content);
-  const tag = content.__tag ?? getDisplayTemplateTag(dtKey);
+  const tag = resolveTag(content, variant);
   const { component: Component, typename } = findComponent(content, { tag });
 
   if (!Component) {
@@ -385,5 +410,4 @@ export function getPreviewUtils(content: OptimizelyComponentProps['content']) {
     },
   };
 }
-
 

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -101,6 +101,32 @@ type OptimizelyComponentProps = {
   displaySettings?: Record<string, string | boolean>;
 };
 
+/**
+ * Attempts to get component from contract types fallback.
+ * If content implements a contract but no component is registered for the contract itself,
+ * tries to find a component using the first type in content._metadata.types array.
+ */
+function getComponentFromContractFallback(
+  content: Record<string, any>,
+  options: { tag?: string },
+): React.ComponentType<any> | undefined {
+  if (
+    typeof content === 'object' &&
+    content !== null &&
+    '_metadata' in content &&
+    content._metadata &&
+    typeof content._metadata === 'object' &&
+    content._metadata !== null &&
+    'types' in content._metadata
+  ) {
+    const types = content._metadata.types;
+    if (Array.isArray(types) && types.length > 0) {
+      return componentRegistry?.getComponent(types[0], options);
+    }
+  }
+  return undefined;
+}
+
 export async function OptimizelyComponent({ content, displaySettings, ...props }: OptimizelyComponentProps) {
   if (!content) {
     throw new OptimizelyReactError('OptimizelyComponent requires a valid content prop. Received null or undefined.');
@@ -110,9 +136,14 @@ export async function OptimizelyComponent({ content, displaySettings, ...props }
     throw new OptimizelyReactError('You should call `initReactComponentRegistry` first');
   }
   const dtKey = content.__composition?.displayTemplateKey ?? content.displayTemplateKey;
-  const Component = await componentRegistry.getComponent(content.__typename, {
-    tag: content.__tag ?? getDisplayTemplateTag(dtKey),
-  });
+  const tag = content.__tag ?? getDisplayTemplateTag(dtKey);
+
+  let Component = componentRegistry.getComponent(content.__typename, { tag });
+
+  // If component not found, try contract types fallback
+  if (!Component) {
+    Component = getComponentFromContractFallback(content, { tag });
+  }
 
   if (!Component) {
     return (

--- a/packages/optimizely-cms-sdk/src/util/baseTypeUtil.ts
+++ b/packages/optimizely-cms-sdk/src/util/baseTypeUtil.ts
@@ -33,19 +33,6 @@ export function toBaseTypeFragmentKey(key: string): string {
 }
 
 /**
- * Gets the fragment name for a content type.
- * @param key - The content type key.
- * @returns The fragment name to use in GraphQL fragment references.
- */
-export function getFragmentName(key: string): string {
-  // Base types keep original key as fragment name (e.g., "_image" not "_Image")
-  if (isBaseType(key)) {
-    return key;
-  }
-  return key;
-}
-
-/**
  * Check if the keyName is a Media type
  * @param key keyName of the content type
  * @returns boolean

--- a/packages/optimizely-cms-sdk/src/util/baseTypeUtil.ts
+++ b/packages/optimizely-cms-sdk/src/util/baseTypeUtil.ts
@@ -33,6 +33,19 @@ export function toBaseTypeFragmentKey(key: string): string {
 }
 
 /**
+ * Gets the fragment name for a content type.
+ * @param key - The content type key.
+ * @returns The fragment name to use in GraphQL fragment references.
+ */
+export function getFragmentName(key: string): string {
+  // Base types keep original key as fragment name (e.g., "_image" not "_Image")
+  if (isBaseType(key)) {
+    return key;
+  }
+  return key;
+}
+
+/**
  * Check if the keyName is a Media type
  * @param key keyName of the content type
  * @returns boolean

--- a/packages/optimizely-cms-sdk/src/util/general.ts
+++ b/packages/optimizely-cms-sdk/src/util/general.ts
@@ -1,0 +1,3 @@
+export function toArray<T>(item: T[] | T): T[] {
+  return Array.isArray(item) ? item : [item];
+}

--- a/samples/nextjs-template/optimizely.config.mjs
+++ b/samples/nextjs-template/optimizely.config.mjs
@@ -1,7 +1,7 @@
 import { buildConfig } from '@optimizely/cms-sdk';
 
 export default buildConfig({
-  components: ['./src/components/**.tsx'],
+  components: ['./src/components/**.tsx', './src/components/**.ts'],
   propertyGroups: [
     {
       key: 'seo',

--- a/templates/alloy-template/optimizely.config.mjs
+++ b/templates/alloy-template/optimizely.config.mjs
@@ -1,7 +1,7 @@
 import { buildConfig } from '@optimizely/cms-sdk';
 
 export default buildConfig({
-  components: ['./src/components/*.tsx', './src/components/**/*.tsx'],
+  components: ['./src/components/*.tsx', './src/components/**/*.tsx', './src/components/contracts/*.ts'],
   propertyGroups: [
     {
       key: 'SEO',

--- a/templates/alloy-template/src/app/layout.tsx
+++ b/templates/alloy-template/src/app/layout.tsx
@@ -16,6 +16,9 @@ import Article, { ArticleContentType } from '@/components/base/Article';
 import BlankSection from '@/components/base/BlankSection';
 import { SEOContentType } from '@/components/base/SEO';
 import Button, { ButtonContentType } from '@/components/base/Button';
+import { TeaserCardContract } from '@/components/contracts/TeaserCard';
+import StandardTeaser from '@/components/base/StandardTeaser';
+import NewsEventsList, { NewsEventsListContentType } from '@/components/base/NewsEventsList';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -51,6 +54,8 @@ initContentTypeRegistry([
   StandardContentType,
   SEOContentType,
   ButtonContentType,
+  TeaserCardContract,
+  NewsEventsListContentType,
 ]);
 
 initReactComponentRegistry({
@@ -61,11 +66,17 @@ initReactComponentRegistry({
     News,
     Notice,
     Product,
-    Standard,
+    Standard: {
+      default: Standard,
+      tags: {
+        mini: StandardTeaser,
+      },
+    },
     Start,
     Teaser,
     BlankSection,
     Button,
+    NewsEventsList,
   },
 });
 
@@ -79,4 +90,5 @@ export default async function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
     </html>
   );
+
 }

--- a/templates/alloy-template/src/app/layout.tsx
+++ b/templates/alloy-template/src/app/layout.tsx
@@ -69,7 +69,7 @@ initReactComponentRegistry({
     Standard: {
       default: Standard,
       tags: {
-        mini: StandardTeaser,
+        teaser: StandardTeaser,
       },
     },
     Start,

--- a/templates/alloy-template/src/components/News.tsx
+++ b/templates/alloy-template/src/components/News.tsx
@@ -98,7 +98,7 @@ function News({ content }: NewsPageProps) {
                 key={index}
                 content={teaser}
                 variant={{
-                  Standard: 'mini',
+                  Standard: 'teaser',
                 }}
               />
             ))}
@@ -110,4 +110,5 @@ function News({ content }: NewsPageProps) {
 }
 
 export default News;
+
 

--- a/templates/alloy-template/src/components/News.tsx
+++ b/templates/alloy-template/src/components/News.tsx
@@ -97,9 +97,7 @@ function News({ content }: NewsPageProps) {
               <OptimizelyComponent
                 key={index}
                 content={teaser}
-                variant={{
-                  Standard: 'teaser',
-                }}
+                tag="teaser"
               />
             ))}
           </div>

--- a/templates/alloy-template/src/components/News.tsx
+++ b/templates/alloy-template/src/components/News.tsx
@@ -1,8 +1,14 @@
 import { contentType, ContentProps, damAssets } from '@optimizely/cms-sdk';
 import { RichText } from '@optimizely/cms-sdk/react/richText';
-import { ComponentContainerProps, getPreviewUtils, OptimizelyComposition } from '@optimizely/cms-sdk/react/server';
+import {
+  ComponentContainerProps,
+  getPreviewUtils,
+  OptimizelyComponent,
+  OptimizelyComposition,
+} from '@optimizely/cms-sdk/react/server';
 import { StandardContentType } from './Standard';
 import { SEOContentType } from './base/SEO';
+import { TeaserCardContract } from './contracts/TeaserCard';
 
 export const NewsContentType = contentType({
   key: 'News',
@@ -21,6 +27,14 @@ export const NewsContentType = contentType({
     description: {
       type: 'string',
       displayName: 'Description',
+    },
+    teasers: {
+      type: 'array',
+      items: {
+        type: 'content',
+        allowedTypes: [TeaserCardContract],
+      },
+      displayName: 'Teasers',
     },
     main_body: {
       type: 'richText',
@@ -48,8 +62,7 @@ function ComponentWrapper({ children, node }: ComponentContainerProps) {
 }
 
 function News({ content }: NewsPageProps) {
-  const { pa, src } = getPreviewUtils(content);
-  const { getAlt, getSrcset, isDamImageAsset } = damAssets(content);
+  const { pa } = getPreviewUtils(content);
 
   return (
     <main className='bg-white'>
@@ -72,23 +85,23 @@ function News({ content }: NewsPageProps) {
 
             {/* Main Body Content */}
             <RichText {...pa('main_body')} content={content.main_body?.json} className='space-y-4 sm:space-y-6' />
-
-            {/* Media Asset - handles images, videos, and files */}
-            {isDamImageAsset(content.image) && (
-              <div className='overflow-hidden rounded-lg'>
-                <img
-                  {...pa('image')}
-                  src={src(content.image)}
-                  srcSet={getSrcset(content.image)}
-                  alt={getAlt(content.image, 'Teaser Image')}
-                  className='h-auto w-full object-cover aspect-video sm:aspect-auto sm:max-h-100 md:max-h-125 lg:max-h-150'
-                />
-              </div>
-            )}
           </div>
 
           <div className='flex flex-col space-y-6 sm:space-y-8'>
             <OptimizelyComposition nodes={content.composition.nodes ?? []} ComponentWrapper={ComponentWrapper} />
+          </div>
+
+          {/* Teasers - Full Width */}
+          <div {...pa('teasers')} className='lg:col-span-2 w-full space-y-4'>
+            {content.teasers?.map((teaser, index) => (
+              <OptimizelyComponent
+                key={index}
+                content={teaser}
+                variant={{
+                  Standard: 'mini',
+                }}
+              />
+            ))}
           </div>
         </div>
       </div>
@@ -97,3 +110,4 @@ function News({ content }: NewsPageProps) {
 }
 
 export default News;
+

--- a/templates/alloy-template/src/components/Standard.tsx
+++ b/templates/alloy-template/src/components/Standard.tsx
@@ -2,12 +2,14 @@ import { contentType, ContentProps } from '@optimizely/cms-sdk';
 import { RichText } from '@optimizely/cms-sdk/react/richText';
 import { ComponentContainerProps, getPreviewUtils, OptimizelyComposition } from '@optimizely/cms-sdk/react/server';
 import { SEOContentType } from './base/SEO';
+import { TeaserCardContract } from './contracts/TeaserCard';
 
 export const StandardContentType = contentType({
   key: 'Standard',
   displayName: 'Standard Page',
   baseType: '_experience',
   mayContainTypes: ['*'],
+  extends: [TeaserCardContract],
   properties: {
     image: {
       type: 'contentReference',
@@ -20,7 +22,7 @@ export const StandardContentType = contentType({
     },
     description: {
       type: 'string',
-      displayName: 'Description',
+      displayName: 'Teaser Description',
     },
     main_body: {
       type: 'richText',
@@ -48,7 +50,7 @@ function ComponentWrapper({ children, node }: ComponentContainerProps) {
 }
 
 function Standard({ content }: StandardPageProps) {
-  const { pa } = getPreviewUtils(content);
+  const { pa, src } = getPreviewUtils(content);
   return (
     <main className='bg-white'>
       <div className='mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8 md:py-10 lg:px-8 lg:py-12'>
@@ -69,6 +71,11 @@ function Standard({ content }: StandardPageProps) {
           {/* Main Body Content */}
           <RichText {...pa('main_body')} content={content.main_body?.json} className='space-y-4 sm:space-y-6' />
 
+          {/* Teasers Image */}
+          <div>
+            {content.image && <img src={src(content.image)} className='w-full h-full object-cover rounded-lg' />}
+          </div>
+
           {/* section Area */}
           <div className='flex flex-col space-y-6 sm:space-y-8'>
             <OptimizelyComposition nodes={content.composition.nodes ?? []} ComponentWrapper={ComponentWrapper} />
@@ -80,3 +87,5 @@ function Standard({ content }: StandardPageProps) {
 }
 
 export default Standard;
+
+

--- a/templates/alloy-template/src/components/base/NewsEventsList.tsx
+++ b/templates/alloy-template/src/components/base/NewsEventsList.tsx
@@ -51,9 +51,7 @@ function NewsEventsList({ content }: NewsEventsListProps) {
             <OptimizelyComponent
               key={index}
               content={teaser}
-              variant={{
-                Standard: 'teaser',
-              }}
+              tag="teaser"
             />
           );
         })}

--- a/templates/alloy-template/src/components/base/NewsEventsList.tsx
+++ b/templates/alloy-template/src/components/base/NewsEventsList.tsx
@@ -52,7 +52,7 @@ function NewsEventsList({ content }: NewsEventsListProps) {
               key={index}
               content={teaser}
               variant={{
-                Standard: 'mini',
+                Standard: 'teaser',
               }}
             />
           );
@@ -70,4 +70,5 @@ function NewsEventsList({ content }: NewsEventsListProps) {
 }
 
 export default NewsEventsList;
+
 

--- a/templates/alloy-template/src/components/base/NewsEventsList.tsx
+++ b/templates/alloy-template/src/components/base/NewsEventsList.tsx
@@ -46,9 +46,17 @@ function NewsEventsList({ content }: NewsEventsListProps) {
 
       {/* Teasers List */}
       <div className='space-y-6'>
-        {content.teasers?.map((teaser, index) => (
-          <OptimizelyComponent key={index} content={teaser} />
-        ))}
+        {content.teasers?.map((teaser, index) => {
+          return (
+            <OptimizelyComponent
+              key={index}
+              content={teaser}
+              variant={{
+                Standard: 'mini',
+              }}
+            />
+          );
+        })}
       </div>
 
       {/* Call to Action Button */}

--- a/templates/alloy-template/src/components/base/NewsEventsList.tsx
+++ b/templates/alloy-template/src/components/base/NewsEventsList.tsx
@@ -1,0 +1,65 @@
+import { ContentProps, contentType } from '@optimizely/cms-sdk';
+import { OptimizelyComponent } from '@optimizely/cms-sdk/react/server';
+import { TeaserCardContract } from '../contracts/TeaserCard';
+import { ButtonContentType } from './Button';
+
+export const NewsEventsListContentType = contentType({
+  key: 'NewsEventsList',
+  displayName: 'News & Events List',
+  baseType: '_component',
+  description: 'Component for rendering list of news and events.',
+  properties: {
+    title: {
+      type: 'string',
+      displayName: 'Title',
+      group: 'Content',
+    },
+    teasers: {
+      type: 'array',
+      items: {
+        type: 'content',
+        allowedTypes: [TeaserCardContract],
+      },
+      displayName: 'List of Teasers',
+    },
+    call_to_action: {
+      type: 'component',
+      contentType: ButtonContentType,
+      displayName: 'Call to Action Text',
+      group: 'Content',
+    },
+  },
+  compositionBehaviors: ['sectionEnabled'],
+});
+
+export type NewsEventsListProps = {
+  content: ContentProps<typeof NewsEventsListContentType>;
+};
+
+function NewsEventsList({ content }: NewsEventsListProps) {
+  return (
+    <div className='space-y-8'>
+      {/* Title */}
+      {content.title && (
+        <h2 className='text-3xl md:text-3xl font-bold text-gray-900 uppercase tracking-tight'>{content.title}</h2>
+      )}
+
+      {/* Teasers List */}
+      <div className='space-y-6'>
+        {content.teasers?.map((teaser, index) => (
+          <OptimizelyComponent key={index} content={teaser} />
+        ))}
+      </div>
+
+      {/* Call to Action Button */}
+      {content.call_to_action && (
+        <div className='pt-4'>
+          <OptimizelyComponent content={content.call_to_action} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default NewsEventsList;
+

--- a/templates/alloy-template/src/components/base/StandardTeaser.tsx
+++ b/templates/alloy-template/src/components/base/StandardTeaser.tsx
@@ -1,0 +1,56 @@
+import { ContentProps, damAssets } from '@optimizely/cms-sdk';
+import { getPreviewUtils } from '@optimizely/cms-sdk/react/server';
+import { StandardContentType } from '../Standard';
+import Link from 'next/link';
+
+type StandardTeaserProps = {
+  content: ContentProps<typeof StandardContentType>;
+};
+
+function StandardTeaser({ content }: StandardTeaserProps) {
+  const { pa, src } = getPreviewUtils(content);
+  const { getAlt } = damAssets(content);
+
+  const href = content._metadata.url.default || '#';
+
+  return (
+    <Link
+      href={href}
+      className='group grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-6  items-start w-full hover:opacity-90 transition-opacity'
+    >
+      {/* Image Section */}
+      <div {...pa('image')} className='w-full h-48'>
+        {content.image ?
+          <img
+            src={src(content.image)}
+            alt={getAlt(content.image, 'Teaser Image')}
+            className='w-full h-48 object-cover rounded-lg'
+          />
+        : <div
+            className='w-full h-48 flex items-center justify-center rounded-lg'
+            style={{ backgroundColor: 'rgb(255 175 32 / 55%)' }}
+          >
+            <img src={'/logo.png'} className='w-18 h-18 object-cover rounded-lg' />
+          </div>
+        }
+      </div>
+
+      {/* Content Section */}
+      <div className='mx-2'>
+        <h2
+          {...pa('heading')}
+          className='text-lg md:text-xl lg:text-2xl font-bold text-gray-900 uppercase tracking-tight group-hover:text-teal-600 transition-colors'
+        >
+          {content.heading}
+        </h2>
+        <p {...pa('description')} className='text-xs md:text-sm lg:text-base text-gray-700 leading-relaxed'>
+          {content.description}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+export default StandardTeaser;
+
+

--- a/templates/alloy-template/src/components/contracts/TeaserCard.ts
+++ b/templates/alloy-template/src/components/contracts/TeaserCard.ts
@@ -1,0 +1,21 @@
+import { contract } from '@optimizely/cms-sdk';
+
+export const TeaserCardContract = contract({
+  key: 'TeaserCard',
+  displayName: 'Teaser Card',
+  properties: {
+    heading: {
+      type: 'string',
+      displayName: 'Teaser Text',
+    },
+    description: {
+      type: 'string',
+      displayName: 'Teaser Description',
+    },
+    image: {
+      type: 'contentReference',
+      displayName: 'Teaser Image',
+    },
+  },
+});
+


### PR DESCRIPTION
 - New contract() function in the SDK for defining contracts
- Content types can extend contracts
- CLI generates separate contract files during pull operations
- Added simple explanation in the docs for contracts
- Fixed minor race condition in tests
- Add type inference for content types extending contracts
- Add fragment generation for contracts
- Modify render logic to handle contracts