### PR TITLE
[WIP] CMS-51933 Add support for enum properties with format options in content model

### DIFF
--- a/docs/3-modelling.md
+++ b/docs/3-modelling.md
@@ -181,6 +181,40 @@ const LandingPageType = contentType({
 
 The `component` type requires a `contentType` field specifying which component type to use.
 
+### Enum Properties
+
+String properties support enums for dropdown or multi-select UI. Use the `format` field to control selection behavior:
+
+- **`'selectOne'`** - Single selection dropdown
+- **`'selectMany'`** - Multiple selection checkboxes
+
+```ts
+properties: {
+  category: {
+    type: 'string',
+    format: 'selectOne',  // Dropdown for single choice
+    enum: [
+      { value: 'tech', displayName: 'Technology' },
+      { value: 'news', displayName: 'News' },
+      { value: 'sports', displayName: 'Sports' },
+    ],
+    displayName: 'Article Category',
+  },
+  tags: {
+    type: 'string',
+    format: 'selectMany',  // Checkboxes for multiple choices
+    enum: [
+      { value: 'featured', displayName: 'Featured' },
+      { value: 'trending', displayName: 'Trending' },
+      { value: 'breaking', displayName: 'Breaking News' },
+    ],
+    displayName: 'Article Tags',
+  },
+}
+```
+
+> **Note:** The `format` field (`selectOne` or `selectMany`) is only available when `enum` is defined on string properties.
+
 ### Indexing Types
 
 The `indexingType` field controls how the property is indexed for search:

--- a/packages/optimizely-cms-sdk/src/model/properties.ts
+++ b/packages/optimizely-cms-sdk/src/model/properties.ts
@@ -6,6 +6,8 @@ export type AnyProperty = ArrayProperty<ArrayItems> | ArrayItems;
 
 export type INDEX_TYPE = 'disabled' | 'queryable' | 'searchable';
 
+type ENUM_FORMAT_TYPES = 'selectOne' | 'selectMany';
+
 /** A "Base" content type property that includes all common attributes for all content type properties */
 type BaseProperty = {
   format?: string;
@@ -19,6 +21,8 @@ type BaseProperty = {
 };
 
 type WithEnum<T> = {
+  //The `format` fields will only give options `selectOne` and `selectMany` if the property has type `string`. Otherwise, it can be any string.
+  format?: T extends string ? ENUM_FORMAT_TYPES : string;
   enum?: { value: T; displayName: string }[];
 };
 


### PR DESCRIPTION
- Add format values `selectOne` and `selectMany` when enum's type is `string`.
- Add documentation for format.