### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "content-js-sdk",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "license": "Apache-2.0",
   "author": "",

--- a/packages/optimizely-cms-cli/package.json
+++ b/packages/optimizely-cms-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/cms-cli",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "CLI application for integration with Optimizely CMS",
   "repository": {
     "url": "https://github.com/episerver/content-js-sdk.git"

--- a/packages/optimizely-cms-sdk/package.json
+++ b/packages/optimizely-cms-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/cms-sdk",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "JavaScript tools for integration with Optimizely CMS",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Release version 2.0.0 for both @optimizely/cms-cli and @optimizely/cms-sdk packages.