### PR TITLE
CMS-51995 Implement fallback logic in ComponentRegistry for graphql aliases ending with "Property"

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -10,7 +10,7 @@ import {
   DAM_ASSET_FRAGMENTS,
 } from '../util/baseTypeUtil.js';
 import { checkTypeConstraintIssues } from '../util/fragmentConstraintChecks.js';
-import { GraphMissingContentTypeError } from './error.js';
+import { GraphMissingContentTypeError, GraphQueryGenerationError } from './error.js';
 
 /**
  * Options for controlling GraphQL fragment generation behavior.
@@ -249,6 +249,14 @@ export function createFragment(
   suffix: string = '',
   options: FragmentOptions = {},
 ): string[] {
+  // Validate content type name before fragment generation
+  if (!contentTypeName || contentTypeName === 'undefined') {
+    throw new GraphQueryGenerationError({
+      contentType: contentTypeName,
+      parentContentType: visited.values().next().value,
+    });
+  }
+
   const { damEnabled = false, maxFragmentThreshold = 100, includeBaseFragments = true } = options;
   const fragmentName = `${contentTypeName}${suffix}`;
   if (visited.has(fragmentName)) return []; // cyclic ref guard
@@ -457,3 +465,4 @@ function resolveAllowedTypes(
 
   return result;
 }
+

--- a/packages/optimizely-cms-sdk/src/graph/error.ts
+++ b/packages/optimizely-cms-sdk/src/graph/error.ts
@@ -35,6 +35,45 @@ export class GraphMissingContentTypeError extends OptimizelyGraphError {
   }
 }
 
+/**
+ * Thrown when GraphQL query generation fails due to invalid content type definitions.
+ */
+export class GraphQueryGenerationError extends OptimizelyGraphError {
+  parentContentType?: string;
+  contentType?: string;
+  propertyName?: string;
+
+  constructor(options?: { parentContentType?: string; contentType?: string; propertyName?: string }) {
+    let message: string;
+
+    // Special case: undefined content type
+    if (!options?.contentType || options.contentType === 'undefined') {
+      const parentInfo =
+        options?.parentContentType ?
+          `\nDetected in property of type 'component' or 'content' within parent content type "${options?.parentContentType}".\n` +
+          `Check the 'contentType', 'allowedTypes', or 'restrictedTypes' property fields.\n\n`
+        : '\n\n';
+      message =
+        `Content type is undefined. ${parentInfo}Common causes:\n` +
+        `- Content type defined in client component - not serializable across server/client boundary\n` +
+        `- Content type imported before it's initialized\n\n` +
+        `To fix:\n` +
+        `1. Move content type definitions to shared file (e.g., content-types.ts) without "use client"\n` +
+        `2. Import content types from shared file\n` +
+        `3. Ensure content type registry initialized before rendering`;
+    } else {
+      // Generic query generation error
+      const prop = options.propertyName ? ` (property "${options.propertyName}")` : '';
+      message = `Failed to generate GraphQL query for content type "${options.contentType}"${prop}`;
+    }
+
+    super(message);
+    this.name = 'GraphQueryGenerationError';
+    this.contentType = options?.contentType;
+    this.propertyName = options?.propertyName;
+  }
+}
+
 /** Errors related to the response */
 export class GraphResponseError extends OptimizelyGraphError {
   request: GraphRequest;
@@ -78,3 +117,4 @@ export class GraphContentResponseError extends GraphHttpResponseError {
     this.name = 'GraphContentResponseError';
   }
 }
+

--- a/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/render/componentRegistry.ts
@@ -85,7 +85,7 @@ export class ComponentRegistry<T> {
       return this.resolver(contentType, options);
     }
 
-    const entry = this.resolver[contentType];
+    const entry = this.getEntryWithFallback(contentType);
 
     if (!options.tag) {
       if (!entry) {
@@ -111,4 +111,25 @@ export class ComponentRegistry<T> {
       getDefaultComponent(entry)
     );
   }
+
+  /** Returns entry with optional fallback to base type when contentType ends with "Property" */
+  private getEntryWithFallback(contentType: string): ComponentEntry<T> | undefined {
+    if (typeof this.resolver === 'function') {
+      return undefined;
+    }
+
+    const entry = this.resolver[contentType];
+    if (entry) {
+      return entry;
+    }
+
+    // Fallback: if contentType ends with "Property", try without the suffix
+    if (contentType.endsWith('Property')) {
+      const baseType = contentType.slice(0, -8); // Remove "Property"
+      return this.resolver[baseType];
+    }
+
+    return undefined;
+  }
 }
+


### PR DESCRIPTION
- Handles fallback for _typename with the suffix "Property".
- Add Error handling for fragment generation. 