### PR TITLE
CMS-52404 Fix DAM asset fragment resolution in compositions

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/__test__/convertProperty.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/convertProperty.test.ts
@@ -56,7 +56,7 @@ describe('createFragment > Fragment threshold warning', () => {
 
   it('should log a warning when fragment count exceeds threshold', () => {
     const result = createFragment('ExplodingType');
-    expect(result).toBeInstanceOf(Array);
+    expect(result.fragments).toBeInstanceOf(Array);
     expect(warnSpy).toHaveBeenCalledOnce();
     expect(warnSpy.mock.calls[0][0]).toMatch(String.raw`generated 107 inner fragments`);
     expect(warnSpy.mock.calls[0][0]).toMatch(
@@ -79,7 +79,7 @@ describe('createFragment > Fragment threshold warning', () => {
 
     initContentTypeRegistry([minimalType, childTypes[0]]);
     const result = createFragment('SafeType');
-    expect(result).toBeInstanceOf(Array);
+    expect(result.fragments).toBeInstanceOf(Array);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/optimizely-cms-sdk/src/graph/__test__/createQuery.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/createQuery.test.ts
@@ -20,7 +20,7 @@ describe('createFragment() simple cases', () => {
     initContentTypeRegistry([ct1]);
 
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -50,7 +50,7 @@ describe('createFragment() simple cases', () => {
     initContentTypeRegistry([ct1]);
 
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -78,7 +78,7 @@ describe('createFragment() simple cases', () => {
     initContentTypeRegistry([ct1]);
 
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -96,7 +96,7 @@ describe('createFragment() simple cases', () => {
     initContentTypeRegistry([ct1]);
 
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -121,7 +121,7 @@ describe('createFragment() with `content` properties. Explicit reference via `al
     });
     initContentTypeRegistry([r1, ct1]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -151,7 +151,7 @@ describe('createFragment() with `content` properties. Explicit reference via `al
     });
     initContentTypeRegistry([r1, r2, ct1]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -185,7 +185,7 @@ describe('createFragment() with `content` properties. Explicit reference via `al
     });
     initContentTypeRegistry([r1, ct1, ct2]);
     const result = await createFragment('ct2');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -212,7 +212,7 @@ describe('createFragment() with `content` properties. Base types', () => {
     });
     initContentTypeRegistry([r1, ct1]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -242,7 +242,7 @@ describe('createFragment() with `content` properties. Base types', () => {
     });
     initContentTypeRegistry([r1, r2, ct1]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -275,7 +275,7 @@ describe('createFragment() with `content` properties. Base types', () => {
 
     initContentTypeRegistry([r1, r2, r3, ct1]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -310,7 +310,7 @@ describe('createFragment() with `content` properties. Base types', () => {
     });
     initContentTypeRegistry([r1, r2, ct2]);
     const result = await createFragment('ct2');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -345,7 +345,7 @@ describe('createFragment() with `content` properties. Allowed and restricted typ
 
     initContentTypeRegistry([r1, r2, r3, ct1]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -379,7 +379,7 @@ describe('createFragment() with `content` properties. Allowed and restricted typ
 
     initContentTypeRegistry([r1, r2, r3, ct1]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -406,7 +406,7 @@ describe('createFragment() with self references', () => {
 
     initContentTypeRegistry([r1]);
     const result = await createFragment('r1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -429,7 +429,7 @@ describe('createFragment() with self references', () => {
 
     initContentTypeRegistry([r1]);
     const result = await createFragment('r1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -452,7 +452,7 @@ describe('createFragment() with self references', () => {
 
     initContentTypeRegistry([r1]);
     const result = await createFragment('r1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -482,7 +482,7 @@ describe('createFragment() with self references', () => {
 
     initContentTypeRegistry([r1]);
     const result = await createFragment('r1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -510,7 +510,7 @@ describe('createFragment() empty objects', () => {
     });
     initContentTypeRegistry([ct1]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -535,7 +535,7 @@ describe('createFragment() empty objects', () => {
     });
     initContentTypeRegistry([ct1]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -563,7 +563,7 @@ describe('createFragment() empty objects', () => {
     const result = await createFragment('ct1');
 
     // Make sure that the query is correct. The `p1 {}` part should have something between the curly braces
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -597,7 +597,7 @@ describe('createFragment() with component properties', () => {
     });
     initContentTypeRegistry([ct1, ctBlock]);
     const result = await createFragment('ct1');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",

--- a/packages/optimizely-cms-sdk/src/graph/__test__/createQueryDAM.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/createQueryDAM.test.ts
@@ -21,13 +21,13 @@ describe('createFragment() with damEnabled for contentReference properties', () 
     });
 
     // Should not include ContentReferenceItem fragments
-    expect(result.some(line => line.includes('PublicImageAsset'))).toBe(false);
-    expect(result.some(line => line.includes('PublicVideoAsset'))).toBe(false);
-    expect(result.some(line => line.includes('PublicRawFileAsset'))).toBe(false);
-    expect(result.some(line => line.includes('ContentReferenceItem'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('PublicImageAsset'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('PublicVideoAsset'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('PublicRawFileAsset'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('ContentReferenceItem'))).toBe(false);
 
     // Should only include key and url (no ...ContentReferenceItem)
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -58,12 +58,12 @@ describe('createFragment() with damEnabled for contentReference properties', () 
     });
 
     // Should include all ContentReferenceItem fragments
-    expect(result.some(line => line.includes('PublicImageAsset'))).toBe(true);
-    expect(result.some(line => line.includes('PublicVideoAsset'))).toBe(true);
-    expect(result.some(line => line.includes('PublicRawFileAsset'))).toBe(true);
-    expect(result.some(line => line.includes('ContentReferenceItem'))).toBe(true);
+    expect(result.fragments.some(line => line.includes('PublicImageAsset'))).toBe(true);
+    expect(result.fragments.some(line => line.includes('PublicVideoAsset'))).toBe(true);
+    expect(result.fragments.some(line => line.includes('PublicRawFileAsset'))).toBe(true);
+    expect(result.fragments.some(line => line.includes('ContentReferenceItem'))).toBe(true);
 
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment PublicImageAsset on cmp_PublicImageAsset { Url Title AltText Description MimeType Height Width Renditions { Id Name Url Width Height } FocalPoint { X Y } Tags { Guid Name } }",
         "fragment PublicVideoAsset on cmp_PublicVideoAsset { Url Title AltText Description MimeType Renditions { Id Name Url Width Height } Tags { Guid Name } }",
@@ -97,8 +97,8 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       includeBaseFragments: true,
     });
 
-    expect(result.some(line => line.includes('ContentReferenceItem'))).toBe(false);
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments.some(line => line.includes('ContentReferenceItem'))).toBe(false);
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -127,8 +127,8 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       includeBaseFragments: true,
     });
 
-    expect(result.some(line => line.includes('ContentReferenceItem'))).toBe(true);
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments.some(line => line.includes('ContentReferenceItem'))).toBe(true);
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment PublicImageAsset on cmp_PublicImageAsset { Url Title AltText Description MimeType Height Width Renditions { Id Name Url Width Height } FocalPoint { X Y } Tags { Guid Name } }",
         "fragment PublicVideoAsset on cmp_PublicVideoAsset { Url Title AltText Description MimeType Renditions { Id Name Url Width Height } Tags { Guid Name } }",
@@ -169,26 +169,26 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       damEnabled: false,
       includeBaseFragments: true,
     });
-    expect(resultDisabled.some(line => line.includes('ContentReferenceItem'))).toBe(false);
+    expect(resultDisabled.fragments.some(line => line.includes('ContentReferenceItem'))).toBe(false);
 
     // Test with damEnabled = true
     const resultEnabled = await createFragment('ct1', new Set(), '', {
       damEnabled: true,
       includeBaseFragments: true,
     });
-    expect(resultEnabled.some(line => line.includes('ContentReferenceItem'))).toBe(true);
-    expect(resultEnabled).toMatchInlineSnapshot(`
+    expect(resultEnabled.fragments.some(line => line.includes('ContentReferenceItem'))).toBe(true);
+    expect(resultEnabled.fragments).toMatchInlineSnapshot(`
       [
+        "fragment PublicImageAsset on cmp_PublicImageAsset { Url Title AltText Description MimeType Height Width Renditions { Id Name Url Width Height } FocalPoint { X Y } Tags { Guid Name } }",
+        "fragment PublicVideoAsset on cmp_PublicVideoAsset { Url Title AltText Description MimeType Renditions { Id Name Url Width Height } Tags { Guid Name } }",
+        "fragment PublicRawFileAsset on cmp_PublicRawFileAsset { Url Title Description MimeType Tags { Guid Name } }",
+        "fragment ContentReferenceItem on ContentReference { item { __typename ...PublicImageAsset ...PublicVideoAsset ...PublicRawFileAsset } }",
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
         "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment PublicImageAsset on cmp_PublicImageAsset { Url Title AltText Description MimeType Height Width Renditions { Id Name Url Width Height } FocalPoint { X Y } Tags { Guid Name } }",
-        "fragment PublicVideoAsset on cmp_PublicVideoAsset { Url Title AltText Description MimeType Renditions { Id Name Url Width Height } Tags { Guid Name } }",
-        "fragment PublicRawFileAsset on cmp_PublicRawFileAsset { Url Title Description MimeType Tags { Guid Name } }",
-        "fragment ContentReferenceItem on ContentReference { item { __typename ...PublicImageAsset ...PublicVideoAsset ...PublicRawFileAsset } }",
         "fragment ctBlockProperty on ctBlockProperty { __typename image { key url { ...ContentUrl } ...ContentReferenceItem } }",
         "fragment ct1 on ct1 { __typename ct1__block:block { ...ctBlockProperty } ..._IContent }",
       ]
@@ -219,19 +219,19 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       damEnabled: true,
       includeBaseFragments: true,
     });
-    expect(result.some(line => line.includes('ContentReferenceItem'))).toBe(true);
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments.some(line => line.includes('ContentReferenceItem'))).toBe(true);
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
+        "fragment PublicImageAsset on cmp_PublicImageAsset { Url Title AltText Description MimeType Height Width Renditions { Id Name Url Width Height } FocalPoint { X Y } Tags { Guid Name } }",
+        "fragment PublicVideoAsset on cmp_PublicVideoAsset { Url Title AltText Description MimeType Renditions { Id Name Url Width Height } Tags { Guid Name } }",
+        "fragment PublicRawFileAsset on cmp_PublicRawFileAsset { Url Title Description MimeType Tags { Guid Name } }",
+        "fragment ContentReferenceItem on ContentReference { item { __typename ...PublicImageAsset ...PublicVideoAsset ...PublicRawFileAsset } }",
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
         "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment PublicImageAsset on cmp_PublicImageAsset { Url Title AltText Description MimeType Height Width Renditions { Id Name Url Width Height } FocalPoint { X Y } Tags { Guid Name } }",
-        "fragment PublicVideoAsset on cmp_PublicVideoAsset { Url Title AltText Description MimeType Renditions { Id Name Url Width Height } Tags { Guid Name } }",
-        "fragment PublicRawFileAsset on cmp_PublicRawFileAsset { Url Title Description MimeType Tags { Guid Name } }",
-        "fragment ContentReferenceItem on ContentReference { item { __typename ...PublicImageAsset ...PublicVideoAsset ...PublicRawFileAsset } }",
         "fragment ctRef on ctRef { __typename image { key url { ...ContentUrl } ...ContentReferenceItem } ..._IContent }",
         "fragment ct1 on ct1 { __typename ct1__content:content { __typename ...ctRef } ..._IContent }",
       ]
@@ -258,21 +258,24 @@ describe('createFragment() with damEnabled for contentReference properties', () 
     });
 
     // Should NOT include DAM fragments
-    expect(result.some(line => line.includes('PublicImageAsset'))).toBe(false);
-    expect(result.some(line => line.includes('PublicVideoAsset'))).toBe(false);
-    expect(result.some(line => line.includes('PublicRawFileAsset'))).toBe(false);
-    expect(result.some(line => line.includes('ContentReferenceItem'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('PublicImageAsset'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('PublicVideoAsset'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('PublicRawFileAsset'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('ContentReferenceItem'))).toBe(false);
 
     expect(result).toMatchInlineSnapshot(`
-      [
-        "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
-        "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
-        "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
-        "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
-        "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
-        "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment ct1 on ct1 { __typename ct1__title:title ct1__description:description { html, json } ct1__link:link { ...ContentUrl } ..._IContent }",
-      ]
+      {
+        "fragments": [
+          "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
+          "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
+          "fragment InstanceMetadata on InstanceMetadata { changeset locales expired container owner routeSegment lastModifiedBy path createdBy }",
+          "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
+          "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
+          "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
+          "fragment ct1 on ct1 { __typename ct1__title:title ct1__description:description { html, json } ct1__link:link { ...ContentUrl } ..._IContent }",
+        ],
+        "includesDamAssetsFragments": false,
+      }
     `);
   });
 
@@ -301,8 +304,8 @@ describe('createFragment() with damEnabled for contentReference properties', () 
     });
 
     // Should NOT include DAM fragments since no contentReference anywhere
-    expect(result.some(line => line.includes('ContentReferenceItem'))).toBe(false);
-    expect(result.some(line => line.includes('PublicImageAsset'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('ContentReferenceItem'))).toBe(false);
+    expect(result.fragments.some(line => line.includes('PublicImageAsset'))).toBe(false);
   });
 });
 

--- a/packages/optimizely-cms-sdk/src/graph/__test__/createQueryExperiences.fixtures.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/createQueryExperiences.fixtures.ts
@@ -37,4 +37,15 @@ const ExpSection = contentType({
   },
 });
 
-export const allContentTypes = [MyExperience, CallToAction, CallToAction2, ExpSection];
+const ImageComponent = contentType({
+  baseType: '_component',
+  key: 'ImageComponent',
+  displayName: 'Image Component',
+  compositionBehaviors: ['elementEnabled'],
+  properties: {
+    title: { type: 'string' },
+    image: { type: 'contentReference', allowedTypes: ['_image'] },
+  },
+});
+
+export const allContentTypes = [MyExperience, CallToAction, CallToAction2, ExpSection, ImageComponent];

--- a/packages/optimizely-cms-sdk/src/graph/__test__/createQueryExperiences.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/createQueryExperiences.test.ts
@@ -10,7 +10,7 @@ beforeAll(() => {
 describe('createFragment()', () => {
   test('for experience types', async () => {
     const result = await createFragment(MyExperience.key);
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -22,9 +22,25 @@ describe('createFragment()', () => {
         "fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }",
         "fragment CallToAction on CallToAction { __typename CallToAction__label:label CallToAction__link:link ..._IContent }",
         "fragment ExpSection on ExpSection { __typename ExpSection__heading:heading ..._IContent }",
-        "fragment _IComponent on _IComponent { __typename ...CallToAction ...ExpSection }",
+        "fragment ImageComponent on ImageComponent { __typename ImageComponent__title:title image { key url { ...ContentUrl } } ..._IContent }",
+        "fragment _IComponent on _IComponent { __typename ...CallToAction ...ExpSection ...ImageComponent }",
         "fragment MyExperience on MyExperience { __typename ..._IContent ..._IExperience }",
       ]
     `);
+    expect(result.includesDamAssetsFragments).toBe(false);
+  });
+
+  test('includes DAM fragments when experience components have contentReference with damEnabled', async () => {
+    const result = await createFragment(MyExperience.key, new Set(), '', { damEnabled: true });
+
+    // Should include DAM fragments
+    const fragmentsString = result.fragments.join('\n');
+    expect(fragmentsString).toContain('fragment PublicImageAsset');
+    expect(fragmentsString).toContain('fragment PublicVideoAsset');
+    expect(fragmentsString).toContain('fragment PublicRawFileAsset');
+    expect(fragmentsString).toContain('fragment ContentReferenceItem');
+
+    // Should have DAM flag set to true
+    expect(result.includesDamAssetsFragments).toBe(true);
   });
 });

--- a/packages/optimizely-cms-sdk/src/graph/__test__/createQueryMedia.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/createQueryMedia.test.ts
@@ -35,7 +35,7 @@ describe('createFragment() creates types for base types', () => {
     initContentTypeRegistry([ctImage, ctVideo, ctMedia, ctPage]);
 
     const result = await createFragment('ctPage');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",
@@ -64,7 +64,7 @@ describe('createFragment() creates types for base types', () => {
     initContentTypeRegistry([ctImage, ctVideo, ctMedia, ctPage]);
 
     const result = await createFragment('ctPage');
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.fragments).toMatchInlineSnapshot(`
       [
         "fragment MediaMetadata on MediaMetadata { mimeType thumbnail content }",
         "fragment ItemMetadata on ItemMetadata { changeset displayOption }",

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -1,6 +1,10 @@
 import { AnyProperty } from '../model/properties.js';
 import { AnyContentType, MAIN_BASE_TYPES, PermittedTypes } from '../model/contentTypes.js';
-import { getContentType, getAllContentTypes, getContentTypeByBaseType } from '../model/contentTypeRegistry.js';
+import {
+  getContentType,
+  getAllContentTypes,
+  getContentTypeByBaseType,
+} from '../model/contentTypeRegistry.js';
 import {
   getKeyName,
   buildBaseTypeFragments,
@@ -34,6 +38,14 @@ type FragmentOptions = {
    * @default true
    */
   includeBaseFragments?: boolean;
+};
+
+/**
+ * Result of fragment generation containing both the fragment strings and metadata.
+ */
+type FragmentResult = {
+  fragments: string[];
+  includesDamAssetsFragments: boolean;
 };
 
 let allContentTypes: AnyContentType[] = [];
@@ -99,7 +111,12 @@ function convertProperty(
   const result = convertPropertyField(name, property, rootName, suffix, visited, options);
 
   // logs warnings if the fragment generation causes potential issues
-  const warningMessage = checkTypeConstraintIssues(rootName, property, result, maxFragmentThreshold);
+  const warningMessage = checkTypeConstraintIssues(
+    rootName,
+    property,
+    result,
+    maxFragmentThreshold,
+  );
 
   if (warningMessage) {
     console.warn(warningMessage);
@@ -140,13 +157,14 @@ function convertPropertyField(
   if (property.type === 'component') {
     const key = property.contentType.key;
     const fragmentName = `${key}Property`;
-    extraFragments.push(
-      ...createFragment(key, visited, 'Property', {
-        damEnabled,
-        maxFragmentThreshold,
-        includeBaseFragments: false,
-      }),
-    );
+    const componentResult = createFragment(key, visited, 'Property', {
+      damEnabled,
+      maxFragmentThreshold,
+      includeBaseFragments: false,
+    });
+    extraFragments.push(...componentResult.fragments);
+    includesDamAssetsFragments =
+      includesDamAssetsFragments || componentResult.includesDamAssetsFragments;
     fields.push(`${nameInFragment} { ...${fragmentName} }`);
   } else if (property.type === 'content') {
     const allowed = resolveAllowedTypes(property.allowedTypes, property.restrictedTypes);
@@ -157,13 +175,14 @@ function convertPropertyField(
       if (key === '_self') {
         key = rootName;
       }
-      extraFragments.push(
-        ...createFragment(key, visited, '', {
-          damEnabled,
-          maxFragmentThreshold,
-          includeBaseFragments: true,
-        }),
-      );
+      const contentResult = createFragment(key, visited, '', {
+        damEnabled,
+        maxFragmentThreshold,
+        includeBaseFragments: true,
+      });
+      extraFragments.push(...contentResult.fragments);
+      includesDamAssetsFragments =
+        includesDamAssetsFragments || contentResult.includesDamAssetsFragments;
       subfields.push(`...${key}`);
     }
 
@@ -206,9 +225,12 @@ function convertPropertyField(
  * Builds experience GraphQL fragments and their dependencies.
  * @param visited - Set of fragment names already visited to avoid cycles.
  * @param options - Fragment generation options.
- * @returns A list of GraphQL fragment strings.
+ * @returns An object containing fragment strings and DAM usage flag.
  */
-function createExperienceFragments(visited: Set<string>, options: FragmentOptions = {}): string[] {
+function createExperienceFragments(
+  visited: Set<string>,
+  options: FragmentOptions = {},
+): FragmentResult {
   // Fixed fragments for all experiences
   const fixedFragments = [
     'fragment _IExperience on _IExperience { composition {...ICompositionNode }}',
@@ -224,15 +246,26 @@ function createExperienceFragments(visited: Set<string>, options: FragmentOption
     })
     .map(c => c.key);
 
-  // Get the required fragments
-  const extraFragments = experienceNodes
+  // Get the required fragments and track DAM usage
+  const { fragments, includesDamAssetsFragments } = experienceNodes
     .filter(n => !visited.has(n))
-    .flatMap(n => createFragment(n, visited, '', { ...options, includeBaseFragments: true }));
+    .flatMap(n => createFragment(n, visited, '', { ...options, includeBaseFragments: true }))
+    .reduce(
+      (acc, result) => ({
+        fragments: [...acc.fragments, ...result.fragments],
+        includesDamAssetsFragments:
+          acc.includesDamAssetsFragments || result.includesDamAssetsFragments,
+      }),
+      { fragments: [], includesDamAssetsFragments: false } as FragmentResult,
+    );
 
   const nodeNames = experienceNodes.map(n => `...${n}`).join(' ');
   const componentFragment = `fragment _IComponent on _IComponent { __typename ${nodeNames} }`;
 
-  return [...fixedFragments, ...extraFragments, componentFragment];
+  return {
+    fragments: [...fixedFragments, ...fragments, componentFragment],
+    includesDamAssetsFragments,
+  };
 }
 
 /**
@@ -248,7 +281,7 @@ export function createFragment(
   visited: Set<string> = new Set(), // shared across recursion
   suffix: string = '',
   options: FragmentOptions = {},
-): string[] {
+): FragmentResult {
   // Validate content type name before fragment generation
   if (!contentTypeName || contentTypeName === 'undefined') {
     throw new GraphQueryGenerationError({
@@ -259,7 +292,7 @@ export function createFragment(
 
   const { damEnabled = false, maxFragmentThreshold = 100, includeBaseFragments = true } = options;
   const fragmentName = `${contentTypeName}${suffix}`;
-  if (visited.has(fragmentName)) return []; // cyclic ref guard
+  if (visited.has(fragmentName)) return { fragments: [], includesDamAssetsFragments: false }; // cyclic ref guard
   // Refresh registry cache only on the *root* call (avoids redundant reads)
   if (visited.size === 0) refreshCache();
   visited.add(fragmentName);
@@ -308,12 +341,13 @@ export function createFragment(
 
     if (ct.baseType === '_experience') {
       fields.push('..._IExperience');
-      extraFragments.push(
-        ...createExperienceFragments(visited, {
-          damEnabled,
-          maxFragmentThreshold,
-        }),
-      );
+      const experienceResult = createExperienceFragments(visited, {
+        damEnabled,
+        maxFragmentThreshold,
+      });
+      extraFragments.push(...experienceResult.fragments);
+      includesDamAssetsFragments =
+        includesDamAssetsFragments || experienceResult.includesDamAssetsFragments;
     }
   }
 
@@ -328,10 +362,14 @@ export function createFragment(
 
   // Compose unique fragment
   const uniqueFields = [...new Set(fields)].join(' ');
-  return [
+  const fragments = [
     ...new Set(extraFragments), // unique dependency fragments
     `fragment ${fragmentName} on ${parsedFragmentName} { ${uniqueFields} }`,
   ];
+  return {
+    fragments,
+    includesDamAssetsFragments,
+  };
 }
 
 /**
@@ -345,15 +383,16 @@ export function createSingleContentQuery(
   damEnabled: boolean = false,
   maxFragmentThreshold: number = 100,
 ) {
-  const fragment = createFragment(contentType, new Set(), '', {
+  const result = createFragment(contentType, new Set(), '', {
     damEnabled,
     maxFragmentThreshold,
     includeBaseFragments: true,
   });
-  const fragmentName = fragment.length > 0 ? '...' + contentType : '';
+  const fragments = result.fragments;
+  const fragmentName = fragments.length > 0 ? '...' + contentType : '';
 
   return `
-${fragment.join('\n')}
+${fragments.join('\n')}
 query GetContent($where: _ContentWhereInput, $variation: VariationInput) {
   _Content(where: $where, variation: $variation) {
     item {
@@ -382,15 +421,16 @@ export function createMultipleContentQuery(
   damEnabled: boolean = false,
   maxFragmentThreshold: number = 100,
 ) {
-  const fragment = createFragment(contentType, new Set(), '', {
+  const result = createFragment(contentType, new Set(), '', {
     damEnabled,
     maxFragmentThreshold,
     includeBaseFragments: true,
   });
-  const fragmentName = fragment.length > 0 ? '...' + contentType : '';
+  const fragments = result.fragments;
+  const fragmentName = fragments.length > 0 ? '...' + contentType : '';
 
   return `
-${fragment.join('\n')}
+${fragments.join('\n')}
 query ListContent($where: _ContentWhereInput, $variation: VariationInput) {
   _Content(where: $where, variation: $variation) {
     items {
@@ -465,4 +505,3 @@ function resolveAllowedTypes(
 
   return result;
 }
-


### PR DESCRIPTION
## Summary
- Fixed DAM asset fragment resolution when contentReference properties exist within experience components
- Changed `createFragment()` to return metadata about DAM usage alongside fragments
- Updated all fragment generation to track DAM asset inclusion through composition hierarchy

## Problem
When experience types contained components with contentReference properties pointing to DAM assets, the DAM fragments were not being included in the generated GraphQL query if `damEnabled: true` was set, causing resolution failures for nested DAM references.

## Solution
- Modified `createFragment()` return type from `string[]` to `{ fragments: string[], includesDamAssetsFragments: boolean }`
- Propagated DAM usage flag through fragment generation
- Ensured DAM fragments are included when any part of the composition tree requires them
