### PR TITLE
More robust content type name logic

### DIFF
--- a/packages/optimizely-cms-cli/src/utils/generate.ts
+++ b/packages/optimizely-cms-cli/src/utils/generate.ts
@@ -120,7 +120,7 @@ const generateImportPath = (content: JSONContent, fromGroup?: string, toGroup?: 
 const generateName = (content: JSONContent) => {
   const cleaned = cleanKey(content.key);
 
-  if (commonKeyContents.some(it => cleaned.toLowerCase().includes(it.toLowerCase())))
+  if (commonKeyContents.some(it => cleaned.endsWith(it)))
     return cleaned;
 
   const ending =


### PR DESCRIPTION
This fixes inconsistent naming of generated content types where the previous code simply did a lowercase (includes)-comparison on the type name and a commonKeyContents array (['Contract', 'CT', 'ContentType', 'DT', 'DisplayTemplate']).

Before:
StartPage -> StartPageCT
ContactPage -> ContactPage

After:
StartPage -> StartPageCT
ContactPage -> ContactPageCT