### PR TITLE
Better quote handling on imported types

### DIFF
--- a/packages/optimizely-cms-cli/src/tests/generate.test.ts
+++ b/packages/optimizely-cms-cli/src/tests/generate.test.ts
@@ -357,6 +357,44 @@ describe('generateCode - edge cases', () => {
     expect(result).toContain("nodeType: 'row'");
   });
 
+  it('should preserve double quotes in string values (not convert to escaped single quotes)', () => {
+    const contentTypeWithQuotedDesc: ContentType = {
+      key: 'EventPage',
+      displayName: 'Event Page',
+      baseType: '_page',
+      isContract: false,
+      properties: {
+        StartTime: {
+          type: 'dateTime',
+          displayName: 'Starttid',
+          description: 'She said, "What a beautiful day!"',
+        } as any,
+      },
+    };
+
+    const result = generateCode(contentTypeWithQuotedDesc, mockManifest, false);
+    expect(result).toContain(`'She said, "What a beautiful day!"'`);
+    expect(result).not.toContain(`\\'What a beautiful day\\'`);
+  });
+
+  it('should escape literal single quotes in string values', () => {
+    const contentTypeWithSingleQuoteDesc: ContentType = {
+      key: 'EventPage',
+      displayName: 'Event Page',
+      baseType: '_page',
+      isContract: false,
+      properties: {
+        Info: {
+          type: 'string',
+          description: "it's a beautiful day",
+        } as any,
+      },
+    };
+
+    const result = generateCode(contentTypeWithSingleQuoteDesc, mockManifest, false);
+    expect(result).toContain(`'it\\'s a beautiful day'`);
+  });
+
   it('should handle content type with multiple imports from same group', () => {
     const pageWithMultipleComponents: ContentType = {
       key: 'RichPage',

--- a/packages/optimizely-cms-cli/src/utils/generate.ts
+++ b/packages/optimizely-cms-cli/src/utils/generate.ts
@@ -196,7 +196,16 @@ const cleanKey = (key: string) => {
   return cleaned;
 };
 
-const cleanupString = (item: string) => item.replaceAll(/"(\w+)":/g, '$1:').replaceAll('"', "'");
+const cleanupString = (item: string) =>
+  item
+    // Remove quotes from object keys: "key": → key:
+    .replaceAll(/"(\w+)":/g, '$1:')
+    // Convert JSON string literals from double-quoted to single-quoted.
+    // For each matched string value: unescape \" → " (safe inside single quotes)
+    // and escape any literal ' → \' to avoid breaking the single-quoted string.
+    .replaceAll(/"((?:[^"\\]|\\.)*)"/g, (_, inner: string) =>
+      `'${inner.replaceAll('\\"', '"').replaceAll("'", "\\'")}'`,
+    );
 
 const findContent = (key: string, manifest: Manifest) =>
   manifest.contentTypes.find(it => it.key === key) ||


### PR DESCRIPTION
The current handling of quotes in string properties is broken. This should fix that.

Before:
"She said, \"It's a beautiful day.\"" -> 'She said, \'It's a beautiful day.\''

After:
"She said, \"It's a beautiful day.\"" -> 'She said, "It\'s a beautiful day."'