### PR TITLE
CMS-52733 displaySettings not forwarded to OptimizelyComponent for component nodes in OptimizelyComposition

### DIFF
--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -255,6 +255,7 @@ export function OptimizelyComposition({
               ...node.component,
               __tag: tag,
             }}
+            displaySettings={parsedDisplaySettings}
           />
         </Wrapper>
       );


### PR DESCRIPTION
In OptimizelyComposition, parsedDisplaySettings was passed to ComponentWrapper but not to the inner OptimizelyComponent for component nodes — causing displaySettings to always be undefined in components that use display template settings.