### PR TITLE
CMS-52780 filter out only built-in content types

### DIFF
--- a/packages/optimizely-cms-cli/src/commands/config/pull.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/pull.ts
@@ -7,7 +7,7 @@ import { BaseCommand } from '../../baseCommand.js';
 import { mkdir } from 'node:fs/promises';
 import { createApiClient } from '../../service/cmsRestClient.js';
 import { Manifest } from '../../utils/manifest.js';
-import { filterSystemContentTypes } from '../../utils/mapping.js';
+import { filterOutBuiltinTypes } from '../../utils/mapping.js';
 import { generateCode, generateFilePath, generateGroups } from '../../utils/generate.js';
 import { getRelevantPath, makeDirs, makeFiles } from '../../utils/make.js';
 import { formatCounts, validateManifest } from '../../utils/general.js';
@@ -203,7 +203,7 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
       }
 
       const manifest = response as unknown as Manifest;
-      manifest.contentTypes = filterSystemContentTypes(manifest.contentTypes);
+      manifest.contentTypes = filterOutBuiltinTypes(manifest.contentTypes);
 
       // Show count in spinner text
       const contentTypeCount = manifest.contentTypes.length;

--- a/packages/optimizely-cms-cli/src/utils/mapping.ts
+++ b/packages/optimizely-cms-cli/src/utils/mapping.ts
@@ -244,19 +244,13 @@ function mapAllowedRestrictedTypes(updatedValue: any, parentKey: string) {
 }
 
 /**
- * Filters out system-generated and media content types.
- * Removes content types with baseType of _image, _video, _media
- * and content types with key of BlankExperience or BlankSection.
+ * Filters out built-in content types (i.e. BlankExperience and BlankSection).
  *
  * @param contentTypes - Array of content types to filter
  * @returns Filtered array of content types
  */
-export function filterSystemContentTypes(contentTypes: ContentType[]): ContentType[] {
-  return contentTypes.filter(
-    ct =>
-      !['_image', '_video', '_media'].includes(ct.baseType ?? '') &&
-      !['BlankExperience', 'BlankSection'].includes(ct.key),
-  );
+export function filterOutBuiltinTypes(contentTypes: ContentType[]): ContentType[] {
+  return contentTypes.filter(ct => !['BlankExperience', 'BlankSection'].includes(ct.key));
 }
 
 /**


### PR DESCRIPTION
Filter out only built-in content types ('BlankExperience' and 'BlankSection').

Closes #329