### PR TITLE
CMS-52547 Add editorSettings to RichTextProperty and Editorial component

### DIFF
--- a/packages/optimizely-cms-sdk/src/model/properties.ts
+++ b/packages/optimizely-cms-sdk/src/model/properties.ts
@@ -6,6 +6,8 @@ export type AnyProperty = ArrayProperty<ArrayItems> | ArrayItems;
 
 export type INDEX_TYPE = 'disabled' | 'queryable' | 'searchable';
 
+export type RICHTEXT_PRESENT = 'expanded' | 'standard' | 'minimal';
+
 /** A "Base" content type property that includes all common attributes for all content type properties */
 type BaseProperty = {
   format?: string;
@@ -67,7 +69,10 @@ export type DateTimeProperty = BaseProperty & {
   maximum?: string;
 };
 
-export type RichTextProperty = BaseProperty & { type: 'richText' };
+export type RichTextProperty = BaseProperty & {
+  type: 'richText';
+  editorSettings?: { preset: RICHTEXT_PRESENT };
+};
 export type UrlProperty = BaseProperty & { type: 'url' };
 export type IntegerProperty = BaseProperty & {
   type: 'integer';
@@ -109,4 +114,3 @@ export type ComponentProperty<T extends AnyContentType> = BaseProperty & {
 export type LinkProperty = BaseProperty & {
   type: 'link';
 };
-

--- a/packages/optimizely-cms-sdk/src/model/properties.ts
+++ b/packages/optimizely-cms-sdk/src/model/properties.ts
@@ -6,7 +6,7 @@ export type AnyProperty = ArrayProperty<ArrayItems> | ArrayItems;
 
 export type INDEX_TYPE = 'disabled' | 'queryable' | 'searchable';
 
-export type RICHTEXT_PRESENT = 'expanded' | 'standard' | 'minimal';
+export type RICHTEXT_PRESET = 'expanded' | 'standard' | 'minimal';
 
 /** A "Base" content type property that includes all common attributes for all content type properties */
 type BaseProperty = {
@@ -71,7 +71,7 @@ export type DateTimeProperty = BaseProperty & {
 
 export type RichTextProperty = BaseProperty & {
   type: 'richText';
-  editorSettings?: { preset: RICHTEXT_PRESENT };
+  editorSettings?: { preset: RICHTEXT_PRESET };
 };
 export type UrlProperty = BaseProperty & { type: 'url' };
 export type IntegerProperty = BaseProperty & {

--- a/plugins/optimizely-cms-skills/skills/optimizely-model/references/common-pitfalls.md
+++ b/plugins/optimizely-cms-skills/skills/optimizely-model/references/common-pitfalls.md
@@ -221,7 +221,7 @@ featuredImage: {
 title: {
   type: 'string',
   editorSettings: {  // Only valid on richText
-    toolbar: 'minimal'
+    preset: 'minimal'
   }
 }
 ```
@@ -234,7 +234,7 @@ bodyText: {
   displayName: 'Body Text',
   group: 'content',
   editorSettings: {
-    toolbar: 'minimal'  // Now supported!
+    preset: 'minimal'  // Now supported!
   }
 }
 ```

--- a/plugins/optimizely-cms-skills/skills/optimizely-model/references/common-pitfalls.md
+++ b/plugins/optimizely-cms-skills/skills/optimizely-model/references/common-pitfalls.md
@@ -209,30 +209,33 @@ featuredImage: {
 }
 ```
 
-## 7. Using editorSettings for Rich Text
+## 7. Incorrect editorSettings Usage
 
-**Problem:** Adding `editorSettings` field to rich text properties to configure TinyMCE toolbar.
+**Problem:** Using `editorSettings` with wrong structure or on non-richText properties.
 
-**Why it fails:** The `editorSettings` field is not recognized by the SDK. Rich text configuration is handled differently.
+**Why it matters:** `editorSettings` is now supported in SDK for configuring TinyMCE toolbar, but only on `richText` properties.
 
 **Example of what NOT to do:**
 ```typescript
-// ❌ WRONG - editorSettings is not a valid field
-bodyText: {
-  type: 'richText',
-  editorSettings: {  // This field is not supported
+// ❌ WRONG - editorSettings on non-richText property
+title: {
+  type: 'string',
+  editorSettings: {  // Only valid on richText
     toolbar: 'minimal'
   }
 }
 ```
 
-**Solution:** Omit `editorSettings`:
+**Solution:** Use `editorSettings` only on `richText` properties:
 ```typescript
-// ✅ CORRECT - No editorSettings field
+// ✅ CORRECT - editorSettings on richText property
 bodyText: {
   type: 'richText',
   displayName: 'Body Text',
-  group: 'content'
+  group: 'content',
+  editorSettings: {
+    toolbar: 'minimal'  // Now supported!
+  }
 }
 ```
 
@@ -248,4 +251,4 @@ Before finalizing your content type definition:
 - [ ] All required imports are present
 - [ ] File naming follows conventions (e.g., `BlogPage.tsx` for BlogPage type)
 - [ ] Type references use objects (e.g., `ArticleContentType`), not strings (e.g., `'ArticleContentType'`)
-- [ ] No `editorSettings` field on rich text properties
+- [ ] `editorSettings` used only on `richText` properties (not on string/other types)

--- a/templates/alloy-template/src/components/base/Editorial.tsx
+++ b/templates/alloy-template/src/components/base/Editorial.tsx
@@ -10,6 +10,9 @@ export const EditorialContentType = contentType({
     main_body: {
       type: 'richText',
       displayName: 'Main Body',
+      editorSettings: {
+        preset: 'expanded',
+      },
     },
   },
   compositionBehaviors: ['elementEnabled'],


### PR DESCRIPTION
- Added support for `editorSettings` for type `richText`.
- Update common-pitfall section in skills.