### PR TITLE
CMS-52890 Expand contracts when resolving allowed types

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
@@ -402,7 +402,7 @@ describe('Fragment generation of contracts with experiences', () => {
 });
 
 describe('Contract expansion in allowedTypes', () => {
-  it('should expand contracts to include implementing content types', async () => {
+  it('should expand contracts to include implementing content types when expandContracts is true', async () => {
     const CategorizableContract = contract({
       key: 'Categorizable',
       displayName: 'Categorizable',
@@ -465,7 +465,9 @@ describe('Contract expansion in allowedTypes', () => {
       LandingPageContentType,
     ]);
 
-    const result = await createFragment('LandingPage');
+    const result = await createFragment('LandingPage', undefined, undefined, {
+      expandContracts: true,
+    });
 
     const fragmentString = result.fragments.join('\n');
 
@@ -484,5 +486,175 @@ describe('Contract expansion in allowedTypes', () => {
     expect(fragmentString).toContain('...Categorizable');
     expect(fragmentString).toContain('...BlogArticle');
     expect(fragmentString).toContain('...NewsArticle');
+  });
+
+  it('should NOT expand contracts when expandContracts is false', async () => {
+    const CategorizableContract = contract({
+      key: 'Categorizable',
+      displayName: 'Categorizable',
+      properties: {
+        category: {
+          type: 'string',
+        },
+        tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const BlogArticleContentType = contentType({
+      key: 'BlogArticle',
+      displayName: 'Blog Article',
+      baseType: '_page',
+      extends: CategorizableContract,
+      properties: {
+        title: {
+          type: 'string',
+        },
+        body: {
+          type: 'richText',
+        },
+      },
+    });
+
+    const NewsArticleContentType = contentType({
+      key: 'NewsArticle',
+      displayName: 'News Article',
+      baseType: '_page',
+      extends: CategorizableContract,
+      properties: {
+        headline: {
+          type: 'string',
+        },
+        content: {
+          type: 'richText',
+        },
+      },
+    });
+
+    const LandingPageContentType = contentType({
+      key: 'LandingPage',
+      displayName: 'Landing Page',
+      baseType: '_page',
+      properties: {
+        featuredContent: {
+          type: 'content',
+          allowedTypes: [CategorizableContract],
+        },
+      },
+    });
+
+    initContentTypeRegistry([
+      CategorizableContract,
+      BlogArticleContentType,
+      NewsArticleContentType,
+      LandingPageContentType,
+    ]);
+
+    const result = await createFragment('LandingPage', undefined, undefined, {
+      expandContracts: false,
+    });
+
+    const fragmentString = result.fragments.join('\n');
+
+    // Should include the contract
+    expect(fragmentString).toContain('fragment Categorizable on ICategorizable');
+    expect(fragmentString).toContain('Categorizable__category:category');
+    expect(fragmentString).toContain('Categorizable__tags:tags');
+
+    // Should NOT include implementing types
+    expect(fragmentString).not.toContain('fragment BlogArticle on BlogArticle');
+    expect(fragmentString).not.toContain('BlogArticle__title:title');
+    expect(fragmentString).not.toContain('fragment NewsArticle on NewsArticle');
+    expect(fragmentString).not.toContain('NewsArticle__headline:headline');
+  });
+
+  it('should NOT expand contracts by default (when expandContracts is not specified)', async () => {
+    const CategorizableContract = contract({
+      key: 'Categorizable',
+      displayName: 'Categorizable',
+      properties: {
+        category: {
+          type: 'string',
+        },
+      },
+    });
+
+    const BlogArticleContentType = contentType({
+      key: 'BlogArticle',
+      displayName: 'Blog Article',
+      baseType: '_page',
+      extends: CategorizableContract,
+      properties: {
+        title: {
+          type: 'string',
+        },
+      },
+    });
+
+    const LandingPageContentType = contentType({
+      key: 'LandingPage',
+      displayName: 'Landing Page',
+      baseType: '_page',
+      properties: {
+        featuredContent: {
+          type: 'content',
+          allowedTypes: [CategorizableContract],
+        },
+      },
+    });
+
+    initContentTypeRegistry([
+      CategorizableContract,
+      BlogArticleContentType,
+      LandingPageContentType,
+    ]);
+
+    // Call without expandContracts option to test default behavior
+    const result = await createFragment('LandingPage');
+
+    const fragmentString = result.fragments.join('\n');
+
+    // Should include the contract
+    expect(fragmentString).toContain('fragment Categorizable on ICategorizable');
+
+    // Should NOT include implementing type (default is false)
+    expect(fragmentString).not.toContain('fragment BlogArticle on BlogArticle');
+  });
+
+  it('should handle contracts with no implementing types', async () => {
+    const EmptyContract = contract({
+      key: 'EmptyContract',
+      displayName: 'Empty Contract',
+      properties: {
+        field: {
+          type: 'string',
+        },
+      },
+    });
+
+    const PageWithEmptyContract = contentType({
+      key: 'PageWithEmptyContract',
+      displayName: 'Page With Empty Contract',
+      baseType: '_page',
+      properties: {
+        content: {
+          type: 'content',
+          allowedTypes: [EmptyContract],
+        },
+      },
+    });
+
+    initContentTypeRegistry([EmptyContract, PageWithEmptyContract]);
+
+    const result = await createFragment('PageWithEmptyContract', undefined, undefined, {
+      expandContracts: true,
+    });
+
+    const fragmentString = result.fragments.join('\n');
+
+    // Should include the contract even when there are no implementing types
+    expect(fragmentString).toContain('fragment EmptyContract on IEmptyContract');
+    expect(fragmentString).toContain('EmptyContract__field:field');
   });
 });

--- a/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/contract.test.ts
@@ -400,3 +400,89 @@ describe('Fragment generation of contracts with experiences', () => {
     `);
   });
 });
+
+describe('Contract expansion in allowedTypes', () => {
+  it('should expand contracts to include implementing content types', async () => {
+    const CategorizableContract = contract({
+      key: 'Categorizable',
+      displayName: 'Categorizable',
+      properties: {
+        category: {
+          type: 'string',
+        },
+        tags: {
+          type: 'string',
+        },
+      },
+    });
+
+    const BlogArticleContentType = contentType({
+      key: 'BlogArticle',
+      displayName: 'Blog Article',
+      baseType: '_page',
+      extends: CategorizableContract,
+      properties: {
+        title: {
+          type: 'string',
+        },
+        body: {
+          type: 'richText',
+        },
+      },
+    });
+
+    const NewsArticleContentType = contentType({
+      key: 'NewsArticle',
+      displayName: 'News Article',
+      baseType: '_page',
+      extends: CategorizableContract,
+      properties: {
+        headline: {
+          type: 'string',
+        },
+        content: {
+          type: 'richText',
+        },
+      },
+    });
+
+    const LandingPageContentType = contentType({
+      key: 'LandingPage',
+      displayName: 'Landing Page',
+      baseType: '_page',
+      properties: {
+        featuredContent: {
+          type: 'content',
+          allowedTypes: [CategorizableContract],
+        },
+      },
+    });
+
+    initContentTypeRegistry([
+      CategorizableContract,
+      BlogArticleContentType,
+      NewsArticleContentType,
+      LandingPageContentType,
+    ]);
+
+    const result = await createFragment('LandingPage');
+
+    const fragmentString = result.fragments.join('\n');
+
+    expect(fragmentString).toContain('fragment Categorizable on ICategorizable');
+    expect(fragmentString).toContain('Categorizable__category:category');
+    expect(fragmentString).toContain('Categorizable__tags:tags');
+
+    expect(fragmentString).toContain('fragment BlogArticle on BlogArticle');
+    expect(fragmentString).toContain('BlogArticle__title:title');
+    expect(fragmentString).toContain('BlogArticle__body:body');
+
+    expect(fragmentString).toContain('fragment NewsArticle on NewsArticle');
+    expect(fragmentString).toContain('NewsArticle__headline:headline');
+    expect(fragmentString).toContain('NewsArticle__content:content');
+
+    expect(fragmentString).toContain('...Categorizable');
+    expect(fragmentString).toContain('...BlogArticle');
+    expect(fragmentString).toContain('...NewsArticle');
+  });
+});

--- a/packages/optimizely-cms-sdk/src/graph/constants.ts
+++ b/packages/optimizely-cms-sdk/src/graph/constants.ts
@@ -1,0 +1,23 @@
+import { SDK_VERSION } from '../generated/version.js';
+
+/**
+ * Default Optimizely Graph API URL for production environment.
+ */
+export const DEFAULT_GRAPH_URL = 'https://cg.optimizely.com/content/v2';
+
+/**
+ * Default User-Agent string for HTTP requests to Graph API.
+ */
+export const DEFAULT_USER_AGENT = `OptimizelySDK/${SDK_VERSION} (JS)`;
+
+/**
+ * Default maximum number of fragments allowed before logging performance warnings.
+ * Helps prevent excessive GraphQL query complexity from unrestricted content types.
+ */
+export const DEFAULT_MAX_FRAGMENT_THRESHOLD = 100;
+
+/**
+ * Default maximum number of implementing types for a contract before expansion is skipped.
+ * When a contract has more implementing types than this threshold, the contract itself is used without expansion.
+ */
+export const DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT = 10;

--- a/packages/optimizely-cms-sdk/src/graph/constants.ts
+++ b/packages/optimizely-cms-sdk/src/graph/constants.ts
@@ -17,7 +17,8 @@ export const DEFAULT_USER_AGENT = `OptimizelySDK/${SDK_VERSION} (JS)`;
 export const DEFAULT_MAX_FRAGMENT_THRESHOLD = 100;
 
 /**
- * Default maximum number of implementing types for a contract before expansion is skipped.
- * When a contract has more implementing types than this threshold, the contract itself is used without expansion.
+ * Default setting for contract expansion.
+ * When true, contracts are expanded to include all implementing types.
+ * When false, only the contract itself is included without expansion.
  */
-export const DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT = 10;
+export const DEFAULT_EXPAND_CONTRACTS = false;

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -34,7 +34,7 @@ import {
 import { isContract } from '../model/index.js';
 import {
   DEFAULT_MAX_FRAGMENT_THRESHOLD,
-  DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+  DEFAULT_EXPAND_CONTRACTS,
 } from './constants.js';
 
 // TYPE DEFINITIONS
@@ -116,7 +116,7 @@ const processUserTypeProperties = (
   visited: Set<string>,
   options: FragmentOptions,
 ): FragmentInfo => {
-  const { damEnabled = false, maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD } = options;
+  const { damEnabled = false, maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD, expandContracts = DEFAULT_EXPAND_CONTRACTS } = options;
   const props = Object.entries(contentType.properties ?? {}).filter(
     ([, t]) => t.indexingType !== 'disabled',
   );
@@ -129,6 +129,7 @@ const processUserTypeProperties = (
     const result = convertProperty(propKey, prop, contentTypeName, suffix, visited, {
       damEnabled,
       maxFragmentThreshold,
+      expandContracts,
     });
 
     fields.push(...result.fields);
@@ -201,6 +202,7 @@ export const createFragment = (
   const {
     damEnabled = false,
     maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD,
+    expandContracts = DEFAULT_EXPAND_CONTRACTS,
     includeBaseFragments = true,
   } = options;
   const fragmentName = `${contentTypeName}${suffix}`;
@@ -240,6 +242,7 @@ export const createFragment = (
       {
         damEnabled,
         maxFragmentThreshold,
+        expandContracts,
       },
     );
     fields.push(...propResult.fields);
@@ -256,6 +259,7 @@ export const createFragment = (
       const experienceResult = createExperienceFragments(visited, {
         damEnabled,
         maxFragmentThreshold,
+        expandContracts,
       });
       extraFragments.push(...experienceResult.fragments);
       includesDamAssetsFragments =
@@ -293,7 +297,7 @@ const generateSingleContentQuery = (
   contentType: string,
   damEnabled: boolean = false,
   maxFragmentThreshold: number = DEFAULT_MAX_FRAGMENT_THRESHOLD,
-  maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+  expandContracts: boolean = DEFAULT_EXPAND_CONTRACTS,
 ): string => {
   const span = startSingleQuerySpan(contentType, damEnabled);
   const startTime = span ? performance.now() : 0;
@@ -301,7 +305,7 @@ const generateSingleContentQuery = (
   const result = createFragment(contentType, new Set(), '', {
     damEnabled,
     maxFragmentThreshold,
-    maxContractExpansionLimit,
+    expandContracts,
     includeBaseFragments: true,
   });
   const fragments = result.fragments;
@@ -340,7 +344,7 @@ query GetContent($where: _ContentWhereInput, $variation: VariationInput) {
  * @param contentType - The key of the content type to query.
  * @param damEnabled - Whether DAM assets are enabled (default: false).
  * @param maxFragmentThreshold - Maximum fragment threshold for warnings.
- * @param maxContractExpansionLimit - Maximum number of implementing types for a contract before expansion is skipped.
+ * @param expandContracts - Enable or disable contract expansion.
  * @returns A string representing the GraphQL query.
  */
 export const createSingleContentQuery = withQueryCaching(
@@ -352,7 +356,7 @@ const generateMultipleContentQuery = (
   contentType: string,
   damEnabled: boolean = false,
   maxFragmentThreshold: number = DEFAULT_MAX_FRAGMENT_THRESHOLD,
-  maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+  expandContracts: boolean = DEFAULT_EXPAND_CONTRACTS,
 ): string => {
   const span = startMultipleQuerySpan(contentType, damEnabled);
   const startTime = span ? performance.now() : 0;
@@ -360,7 +364,7 @@ const generateMultipleContentQuery = (
   const result = createFragment(contentType, new Set(), '', {
     damEnabled,
     maxFragmentThreshold,
-    maxContractExpansionLimit,
+    expandContracts,
     includeBaseFragments: true,
   });
   const fragments = result.fragments;
@@ -400,7 +404,7 @@ query ListContent($where: _ContentWhereInput, $variation: VariationInput) {
  * @param contentType - The key of the content type to query.
  * @param damEnabled - Whether DAM assets are enabled (default: false).
  * @param maxFragmentThreshold - Maximum fragment threshold for warnings.
- * @param maxContractExpansionLimit - Maximum number of implementing types for a contract before expansion is skipped.
+ * @param expandContracts - Enable or disable contract expansion.
  * @returns A string representing the GraphQL query.
  */
 export const createMultipleContentQuery = withQueryCaching(

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -32,6 +32,10 @@ import {
   FragmentInfo,
 } from '../util/queryUtils.js';
 import { isContract } from '../model/index.js';
+import {
+  DEFAULT_MAX_FRAGMENT_THRESHOLD,
+  DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+} from './constants.js';
 
 // TYPE DEFINITIONS
 
@@ -112,7 +116,7 @@ const processUserTypeProperties = (
   visited: Set<string>,
   options: FragmentOptions,
 ): FragmentInfo => {
-  const { damEnabled = false, maxFragmentThreshold = 100 } = options;
+  const { damEnabled = false, maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD } = options;
   const props = Object.entries(contentType.properties ?? {}).filter(
     ([, t]) => t.indexingType !== 'disabled',
   );
@@ -196,7 +200,7 @@ export const createFragment = (
 
   const {
     damEnabled = false,
-    maxFragmentThreshold = 100,
+    maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD,
     includeBaseFragments = true,
   } = options;
   const fragmentName = `${contentTypeName}${suffix}`;
@@ -288,7 +292,8 @@ export const createFragment = (
 const generateSingleContentQuery = (
   contentType: string,
   damEnabled: boolean = false,
-  maxFragmentThreshold: number = 100,
+  maxFragmentThreshold: number = DEFAULT_MAX_FRAGMENT_THRESHOLD,
+  maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
 ): string => {
   const span = startSingleQuerySpan(contentType, damEnabled);
   const startTime = span ? performance.now() : 0;
@@ -296,6 +301,7 @@ const generateSingleContentQuery = (
   const result = createFragment(contentType, new Set(), '', {
     damEnabled,
     maxFragmentThreshold,
+    maxContractExpansionLimit,
     includeBaseFragments: true,
   });
   const fragments = result.fragments;
@@ -333,7 +339,8 @@ query GetContent($where: _ContentWhereInput, $variation: VariationInput) {
  *
  * @param contentType - The key of the content type to query.
  * @param damEnabled - Whether DAM assets are enabled (default: false).
- * @param maxFragmentThreshold - Maximum fragment threshold for warnings (default: 100).
+ * @param maxFragmentThreshold - Maximum fragment threshold for warnings.
+ * @param maxContractExpansionLimit - Maximum number of implementing types for a contract before expansion is skipped.
  * @returns A string representing the GraphQL query.
  */
 export const createSingleContentQuery = withQueryCaching(
@@ -344,7 +351,8 @@ export const createSingleContentQuery = withQueryCaching(
 const generateMultipleContentQuery = (
   contentType: string,
   damEnabled: boolean = false,
-  maxFragmentThreshold: number = 100,
+  maxFragmentThreshold: number = DEFAULT_MAX_FRAGMENT_THRESHOLD,
+  maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
 ): string => {
   const span = startMultipleQuerySpan(contentType, damEnabled);
   const startTime = span ? performance.now() : 0;
@@ -352,6 +360,7 @@ const generateMultipleContentQuery = (
   const result = createFragment(contentType, new Set(), '', {
     damEnabled,
     maxFragmentThreshold,
+    maxContractExpansionLimit,
     includeBaseFragments: true,
   });
   const fragments = result.fragments;
@@ -390,7 +399,8 @@ query ListContent($where: _ContentWhereInput, $variation: VariationInput) {
  *
  * @param contentType - The key of the content type to query.
  * @param damEnabled - Whether DAM assets are enabled (default: false).
- * @param maxFragmentThreshold - Maximum fragment threshold for warnings (default: 100).
+ * @param maxFragmentThreshold - Maximum fragment threshold for warnings.
+ * @param maxContractExpansionLimit - Maximum number of implementing types for a contract before expansion is skipped.
  * @returns A string representing the GraphQL query.
  */
 export const createMultipleContentQuery = withQueryCaching(

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -26,18 +26,28 @@ import {
   withGetPreviewContentSpan,
   withGetContentSpan,
 } from '../telemetry/spans.js';
-import { SDK_VERSION } from '../generated/version.js';
+import {
+  DEFAULT_GRAPH_URL,
+  DEFAULT_USER_AGENT,
+  DEFAULT_MAX_FRAGMENT_THRESHOLD,
+  DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+} from './constants.js';
 
 /** Configuration for initializing the Optimizely Graph Client */
 export type GraphOptions = {
   /** Your Optimizely Graph API key (Single key in CMS) */
   apiKey: string;
-  /** Optional custom Graph URL (defaults to production: https://cg.optimizely.com/content/v2) */
+  /** Optional custom Graph URL */
   graphUrl?: string;
   /** Optional default host for path filtering */
   host?: string;
-  /** Default maximum fragment threshold for GraphQL queries (default: 100) */
+  /** Default maximum fragment threshold for GraphQL queries */
   maxFragmentThreshold?: number;
+  /**
+   * Maximum number of implementing types for a contract before expansion is skipped
+   * When a contract has more implementing types than this threshold, the contract itself is used without expansion
+   */
+  maxContractExpansionLimit?: number;
   /**
    * Enable or disable server-side caching for all queries.
    * Can be overridden per request.
@@ -315,6 +325,7 @@ export class GraphClient {
   apiKey: string;
   graphUrl: string;
   maxFragmentThreshold: number;
+  maxContractExpansionLimit: number;
   host?: string;
   cache: boolean;
   slot?: GraphSlot;
@@ -323,12 +334,13 @@ export class GraphClient {
   // The key is required, other options have defaults or can be set globally
   constructor(apiKey: string, options: Omit<GraphOptions, 'apiKey'> = {}) {
     this.apiKey = apiKey;
-    this.graphUrl = options.graphUrl || 'https://cg.optimizely.com/content/v2';
-    this.maxFragmentThreshold = options.maxFragmentThreshold ?? 100;
+    this.graphUrl = options.graphUrl || DEFAULT_GRAPH_URL;
+    this.maxFragmentThreshold = options.maxFragmentThreshold ?? DEFAULT_MAX_FRAGMENT_THRESHOLD;
+    this.maxContractExpansionLimit = options.maxContractExpansionLimit ?? DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT;
     this.host = options.host;
     this.cache = options.cache ?? true;
     this.slot = options.slot;
-    this.userAgent = options.userAgent ?? `OptimizelySDK/${SDK_VERSION} (JS)`;
+    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
   }
 
   /** Perform a GraphQL query with variables */
@@ -509,6 +521,7 @@ export class GraphClient {
           contentTypeName,
           damEnabled,
           this.maxFragmentThreshold,
+          this.maxContractExpansionLimit,
         );
         const response = (await this.request(
           query,
@@ -715,6 +728,7 @@ export class GraphClient {
         contentTypeName,
         damEnabled,
         this.maxFragmentThreshold,
+        this.maxContractExpansionLimit,
       );
 
       const response = await this.request(
@@ -872,6 +886,7 @@ export class GraphClient {
           contentTypeName,
           damEnabled,
           this.maxFragmentThreshold,
+          this.maxContractExpansionLimit,
         );
 
         const response = await this.request(

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -30,7 +30,7 @@ import {
   DEFAULT_GRAPH_URL,
   DEFAULT_USER_AGENT,
   DEFAULT_MAX_FRAGMENT_THRESHOLD,
-  DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+  DEFAULT_EXPAND_CONTRACTS,
 } from './constants.js';
 
 /** Configuration for initializing the Optimizely Graph Client */
@@ -44,10 +44,11 @@ export type GraphOptions = {
   /** Default maximum fragment threshold for GraphQL queries */
   maxFragmentThreshold?: number;
   /**
-   * Maximum number of implementing types for a contract before expansion is skipped
-   * When a contract has more implementing types than this threshold, the contract itself is used without expansion
+   * Enable or disable contract expansion.
+   * When true, contracts are expanded to include all implementing types.
+   * When false, only the contract itself is included without expansion.
    */
-  maxContractExpansionLimit?: number;
+  expandContracts?: boolean;
   /**
    * Enable or disable server-side caching for all queries.
    * Can be overridden per request.
@@ -325,7 +326,7 @@ export class GraphClient {
   apiKey: string;
   graphUrl: string;
   maxFragmentThreshold: number;
-  maxContractExpansionLimit: number;
+  expandContracts: boolean;
   host?: string;
   cache: boolean;
   slot?: GraphSlot;
@@ -336,7 +337,7 @@ export class GraphClient {
     this.apiKey = apiKey;
     this.graphUrl = options.graphUrl || DEFAULT_GRAPH_URL;
     this.maxFragmentThreshold = options.maxFragmentThreshold ?? DEFAULT_MAX_FRAGMENT_THRESHOLD;
-    this.maxContractExpansionLimit = options.maxContractExpansionLimit ?? DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT;
+    this.expandContracts = options.expandContracts ?? DEFAULT_EXPAND_CONTRACTS;
     this.host = options.host;
     this.cache = options.cache ?? true;
     this.slot = options.slot;
@@ -521,7 +522,7 @@ export class GraphClient {
           contentTypeName,
           damEnabled,
           this.maxFragmentThreshold,
-          this.maxContractExpansionLimit,
+          this.expandContracts,
         );
         const response = (await this.request(
           query,
@@ -728,7 +729,7 @@ export class GraphClient {
         contentTypeName,
         damEnabled,
         this.maxFragmentThreshold,
-        this.maxContractExpansionLimit,
+        this.expandContracts,
       );
 
       const response = await this.request(
@@ -886,7 +887,7 @@ export class GraphClient {
           contentTypeName,
           damEnabled,
           this.maxFragmentThreshold,
-          this.maxContractExpansionLimit,
+          this.expandContracts,
         );
 
         const response = await this.request(

--- a/packages/optimizely-cms-sdk/src/model/index.ts
+++ b/packages/optimizely-cms-sdk/src/model/index.ts
@@ -7,6 +7,7 @@ import {
   SuppliedContractValues,
 } from './contentTypes.js';
 import { DisplayTemplate, DisplayTemplateVariant } from './displayTemplates.js';
+import { getAllContentTypes } from './contentTypeRegistry.js';
 
 function getMergedProps<T extends AnyContentType>(
   options: T,
@@ -126,6 +127,21 @@ export function isDisplayTemplate(obj: unknown): obj is DisplayTemplate {
     'key' in obj
   );
 }
+
+/**
+ * Finds all content types that extend a given contract.
+ *
+ * @param contract - The contract to search for
+ * @returns Array of content types that extend the contract
+ */
+export const findExtendingContentTypes = (contract: Contract): AnyContentType[] =>
+  getAllContentTypes().filter((entry): entry is AnyContentType => {
+    if (!isContentType(entry)) return false;
+
+    const extendedContracts =
+      Array.isArray(entry.extends) ? entry.extends : [entry.extends];
+    return extendedContracts.some(c => c?.key === contract.key);
+  });
 
 export {
   PropertyGroupType,

--- a/packages/optimizely-cms-sdk/src/util/cache.ts
+++ b/packages/optimizely-cms-sdk/src/util/cache.ts
@@ -1,9 +1,15 @@
+import {
+  DEFAULT_MAX_FRAGMENT_THRESHOLD,
+  DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+} from '../graph/constants.js';
+
 const queryCache = new Map<string, string>();
 
 type QueryGenerator = (
   contentType: string,
   damEnabled?: boolean,
   maxFragmentThreshold?: number,
+  maxContractExpansionLimit?: number,
 ) => string;
 
 /**
@@ -17,16 +23,17 @@ export const withQueryCaching = (
   return (
     contentType: string,
     damEnabled: boolean = false,
-    maxFragmentThreshold: number = 100,
+    maxFragmentThreshold: number = DEFAULT_MAX_FRAGMENT_THRESHOLD,
+    maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
   ): string => {
-    const cacheKey = `${queryType}:${contentType}:${damEnabled}:${maxFragmentThreshold}`;
+    const cacheKey = `${queryType}:${contentType}:${damEnabled}:${maxFragmentThreshold}:${maxContractExpansionLimit}`;
 
     const cached = queryCache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
-    const query = generateQuery(contentType, damEnabled, maxFragmentThreshold);
+    const query = generateQuery(contentType, damEnabled, maxFragmentThreshold, maxContractExpansionLimit);
     queryCache.set(cacheKey, query);
     return query;
   };

--- a/packages/optimizely-cms-sdk/src/util/cache.ts
+++ b/packages/optimizely-cms-sdk/src/util/cache.ts
@@ -1,6 +1,6 @@
 import {
   DEFAULT_MAX_FRAGMENT_THRESHOLD,
-  DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+  DEFAULT_EXPAND_CONTRACTS,
 } from '../graph/constants.js';
 
 const queryCache = new Map<string, string>();
@@ -9,7 +9,7 @@ type QueryGenerator = (
   contentType: string,
   damEnabled?: boolean,
   maxFragmentThreshold?: number,
-  maxContractExpansionLimit?: number,
+  expandContracts?: boolean,
 ) => string;
 
 /**
@@ -24,16 +24,16 @@ export const withQueryCaching = (
     contentType: string,
     damEnabled: boolean = false,
     maxFragmentThreshold: number = DEFAULT_MAX_FRAGMENT_THRESHOLD,
-    maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+    expandContracts: boolean = DEFAULT_EXPAND_CONTRACTS,
   ): string => {
-    const cacheKey = `${queryType}:${contentType}:${damEnabled}:${maxFragmentThreshold}:${maxContractExpansionLimit}`;
+    const cacheKey = `${queryType}:${contentType}:${damEnabled}:${maxFragmentThreshold}:${expandContracts}`;
 
     const cached = queryCache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
-    const query = generateQuery(contentType, damEnabled, maxFragmentThreshold, maxContractExpansionLimit);
+    const query = generateQuery(contentType, damEnabled, maxFragmentThreshold, expandContracts);
     queryCache.set(cacheKey, query);
     return query;
   };

--- a/packages/optimizely-cms-sdk/src/util/fragmentConstraintChecks.ts
+++ b/packages/optimizely-cms-sdk/src/util/fragmentConstraintChecks.ts
@@ -1,4 +1,5 @@
 import { AnyProperty } from '../model/properties.js';
+import { DEFAULT_MAX_FRAGMENT_THRESHOLD } from '../graph/constants.js';
 
 /**
  * Checks if the `allowedTypes` or `restrictedTypes` of a property are undefined or empty.
@@ -36,7 +37,7 @@ function areItemConstraintsMissing(property: AnyProperty): boolean {
  * @param rootName - The root content type name for tracing.
  * @param property - The property definition to check.
  * @param result - The conversion result containing fields and fragments.
- * @param maxFragmentThreshold - Maximum fragment threshold for this check (default: 100).
+ * @param maxFragmentThreshold - Maximum fragment threshold for this check.
  * @returns string | null - A warning message if type constraints are missing or incomplete, otherwise null.
  */
 export function checkTypeConstraintIssues(
@@ -46,7 +47,7 @@ export function checkTypeConstraintIssues(
     fields: string[];
     extraFragments: string[];
   },
-  maxFragmentThreshold: number = 100,
+  maxFragmentThreshold: number = DEFAULT_MAX_FRAGMENT_THRESHOLD,
 ): string | null {
   if (
     (arePropertyConstraintsMissing(property) || areItemConstraintsMissing(property)) &&

--- a/packages/optimizely-cms-sdk/src/util/queryUtils.ts
+++ b/packages/optimizely-cms-sdk/src/util/queryUtils.ts
@@ -16,7 +16,7 @@ import { createFragment } from '../graph/createQuery.js';
 import { isContract, findExtendingContentTypes } from '../model/index.js';
 import {
   DEFAULT_MAX_FRAGMENT_THRESHOLD,
-  DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+  DEFAULT_EXPAND_CONTRACTS,
 } from '../graph/constants.js';
 
 // TYPE DEFINITIONS
@@ -37,10 +37,11 @@ export type FragmentOptions = {
    */
   maxFragmentThreshold?: number;
   /**
-   * Maximum number of implementing types for a contract before expansion is skipped.
-   * When a contract has more implementing types than this threshold, the contract itself is used without expansion.
+   * Enable or disable contract expansion.
+   * When true, contracts are expanded to include all implementing types.
+   * When false, only the contract itself is included without expansion.
    */
-  maxContractExpansionLimit?: number;
+  expandContracts?: boolean;
   /**
    * Whether to include CMS base type fragments (e.g., _IContent, _IPage) in generated fragments.
    * Set to false for component property fragments that don't need base metadata.
@@ -145,11 +146,11 @@ const expandBaseType = (
 
 const expandContract = (
   entry: PermittedTypes | AnyContentType,
-  maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+  expandContracts: boolean = DEFAULT_EXPAND_CONTRACTS,
 ): (PermittedTypes | AnyContentType)[] => {
   if (typeof entry === 'object' && isContract(entry)) {
+    if (!expandContracts) return [entry];
     const extendingTypes = findExtendingContentTypes(entry);
-    if (extendingTypes.length > maxContractExpansionLimit) return [entry];
     return [entry, ...extendingTypes];
   }
 
@@ -160,7 +161,7 @@ const resolveAllowedTypes = (
   allowed: PermittedTypes[] | undefined,
   restricted: PermittedTypes[] | undefined,
   cached: RegistryEntry[],
-  maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+  expandContracts: boolean = DEFAULT_EXPAND_CONTRACTS,
 ): (PermittedTypes | AnyContentType)[] => {
   const baseline = allowed?.length ? allowed : cached;
   const skipSet = buildSkipSet(restricted);
@@ -169,7 +170,7 @@ const resolveAllowedTypes = (
   const seen = new Set<string>();
 
   return baseline
-    .flatMap(entry => expandContract(entry, maxContractExpansionLimit))
+    .flatMap(entry => expandContract(entry, expandContracts))
     .flatMap(entry => expandBaseType(entry, shouldExpandBaseTypes))
     .filter(contentType => {
       const key = getKeyName(contentType);
@@ -221,13 +222,13 @@ const handleContentProperty: PropertyHandler = (
   const {
     damEnabled = false,
     maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD,
-    maxContractExpansionLimit = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+    expandContracts = DEFAULT_EXPAND_CONTRACTS,
   } = options;
   const allowed = resolveAllowedTypes(
     (property as any).allowedTypes,
     (property as any).restrictedTypes,
     getCachedContentTypes(),
-    maxContractExpansionLimit,
+    expandContracts,
   );
 
   const nameInFragment = `${rootName}${suffix}__${name}:${name}`;
@@ -238,6 +239,7 @@ const handleContentProperty: PropertyHandler = (
     const result = createFragment(key, visited, '', {
       damEnabled,
       maxFragmentThreshold,
+      expandContracts,
       includeBaseFragments: true,
     });
     includesDamAssetsFragments =

--- a/packages/optimizely-cms-sdk/src/util/queryUtils.ts
+++ b/packages/optimizely-cms-sdk/src/util/queryUtils.ts
@@ -13,6 +13,11 @@ import { CONTENT_URL_FRAGMENT, getKeyName, isBaseType } from './baseTypeUtil.js'
 import { AnyProperty } from '../model/properties.js';
 import { checkTypeConstraintIssues } from './fragmentConstraintChecks.js';
 import { createFragment } from '../graph/createQuery.js';
+import { isContract, findExtendingContentTypes } from '../model/index.js';
+
+// CONSTANTS
+
+const CONTRACT_EXPANSION_WARNING_COUNT = 10;
 
 // TYPE DEFINITIONS
 
@@ -134,6 +139,25 @@ const expandBaseType = (
   return [entry];
 };
 
+const expandContract = (
+  entry: PermittedTypes | AnyContentType,
+): (PermittedTypes | AnyContentType)[] => {
+  if (typeof entry === 'object' && isContract(entry)) {
+    const extendingTypes = findExtendingContentTypes(entry);
+
+    if (extendingTypes.length > CONTRACT_EXPANSION_WARNING_COUNT) {
+      console.warn(
+        `Contract "${entry.key}" has ${extendingTypes.length} implementing types. ` +
+          `This may result in a large GraphQL query. Consider using explicit allowedTypes instead.`,
+      );
+    }
+
+    return [entry, ...extendingTypes];
+  }
+
+  return [entry];
+};
+
 const resolveAllowedTypes = (
   allowed: PermittedTypes[] | undefined,
   restricted: PermittedTypes[] | undefined,
@@ -146,6 +170,7 @@ const resolveAllowedTypes = (
   const seen = new Set<string>();
 
   return baseline
+    .flatMap(expandContract)
     .flatMap(entry => expandBaseType(entry, shouldExpandBaseTypes))
     .filter(contentType => {
       const key = getKeyName(contentType);

--- a/packages/optimizely-cms-sdk/src/util/queryUtils.ts
+++ b/packages/optimizely-cms-sdk/src/util/queryUtils.ts
@@ -14,10 +14,10 @@ import { AnyProperty } from '../model/properties.js';
 import { checkTypeConstraintIssues } from './fragmentConstraintChecks.js';
 import { createFragment } from '../graph/createQuery.js';
 import { isContract, findExtendingContentTypes } from '../model/index.js';
-
-// CONSTANTS
-
-const CONTRACT_EXPANSION_WARNING_COUNT = 10;
+import {
+  DEFAULT_MAX_FRAGMENT_THRESHOLD,
+  DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+} from '../graph/constants.js';
 
 // TYPE DEFINITIONS
 
@@ -34,9 +34,13 @@ export type FragmentOptions = {
   /**
    * Maximum number of fragments allowed before logging performance warnings.
    * Helps prevent excessive GraphQL query complexity from unrestricted content types.
-   * @default 100
    */
   maxFragmentThreshold?: number;
+  /**
+   * Maximum number of implementing types for a contract before expansion is skipped.
+   * When a contract has more implementing types than this threshold, the contract itself is used without expansion.
+   */
+  maxContractExpansionLimit?: number;
   /**
    * Whether to include CMS base type fragments (e.g., _IContent, _IPage) in generated fragments.
    * Set to false for component property fragments that don't need base metadata.
@@ -141,17 +145,11 @@ const expandBaseType = (
 
 const expandContract = (
   entry: PermittedTypes | AnyContentType,
+  maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
 ): (PermittedTypes | AnyContentType)[] => {
   if (typeof entry === 'object' && isContract(entry)) {
     const extendingTypes = findExtendingContentTypes(entry);
-
-    if (extendingTypes.length > CONTRACT_EXPANSION_WARNING_COUNT) {
-      console.warn(
-        `Contract "${entry.key}" has ${extendingTypes.length} implementing types. ` +
-          `This may result in a large GraphQL query. Consider using explicit allowedTypes instead.`,
-      );
-    }
-
+    if (extendingTypes.length > maxContractExpansionLimit) return [entry];
     return [entry, ...extendingTypes];
   }
 
@@ -162,6 +160,7 @@ const resolveAllowedTypes = (
   allowed: PermittedTypes[] | undefined,
   restricted: PermittedTypes[] | undefined,
   cached: RegistryEntry[],
+  maxContractExpansionLimit: number = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
 ): (PermittedTypes | AnyContentType)[] => {
   const baseline = allowed?.length ? allowed : cached;
   const skipSet = buildSkipSet(restricted);
@@ -170,7 +169,7 @@ const resolveAllowedTypes = (
   const seen = new Set<string>();
 
   return baseline
-    .flatMap(expandContract)
+    .flatMap(entry => expandContract(entry, maxContractExpansionLimit))
     .flatMap(entry => expandBaseType(entry, shouldExpandBaseTypes))
     .filter(contentType => {
       const key = getKeyName(contentType);
@@ -191,7 +190,8 @@ const handleComponentProperty: PropertyHandler = (
   visited: Set<string>,
   options: FragmentOptions,
 ) => {
-  const { damEnabled = false, maxFragmentThreshold = 100 } = options;
+  const { damEnabled = false, maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD } =
+    options;
   const key = (property as any).contentType.key;
 
   const nameInFragment = `${rootName}${suffix}__${name}:${name}`;
@@ -218,11 +218,16 @@ const handleContentProperty: PropertyHandler = (
   visited: Set<string>,
   options: FragmentOptions,
 ) => {
-  const { damEnabled = false, maxFragmentThreshold = 100 } = options;
+  const {
+    damEnabled = false,
+    maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD,
+    maxContractExpansionLimit = DEFAULT_MAX_CONTRACT_EXPANSION_LIMIT,
+  } = options;
   const allowed = resolveAllowedTypes(
     (property as any).allowedTypes,
     (property as any).restrictedTypes,
     getCachedContentTypes(),
+    maxContractExpansionLimit,
   );
 
   const nameInFragment = `${rootName}${suffix}__${name}:${name}`;
@@ -318,7 +323,8 @@ const handleArrayProperty: PropertyHandler = (
   visited: Set<string>,
   options: FragmentOptions,
 ) => {
-  const { damEnabled = false, maxFragmentThreshold = 100 } = options;
+  const { damEnabled = false, maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD } =
+    options;
 
   return convertProperty(name, (property as any).items, rootName, suffix, visited, {
     damEnabled,
@@ -380,7 +386,7 @@ export const convertProperty: PropertyHandler = (
   visited: Set<string>,
   options: FragmentOptions = {},
 ) => {
-  const { maxFragmentThreshold = 100 } = options;
+  const { maxFragmentThreshold = DEFAULT_MAX_FRAGMENT_THRESHOLD } = options;
   const result = convertPropertyField(name, property, rootName, suffix, visited, options);
 
   const warningMessage = checkTypeConstraintIssues(


### PR DESCRIPTION
Tentative fix for reported bug. Needs more discussion overall.
Current solution is to find all content types that extend the contract in allowed types and add them to the fragment directly. The main issue with this is the additional overhead it causes. For now, in cases where there are more than 10 types that extend a contract, a console warning is displayed advising using more explicit allowed types instead. Leaving this as draft for now, until we agree on a solution that we are all happy with.