### PR TITLE
CMS-53372 Create single file when output has extension

### DIFF
--- a/packages/optimizely-cms-cli/README.md
+++ b/packages/optimizely-cms-cli/README.md
@@ -110,6 +110,9 @@ optimizely-cms-cli config pull
 # With output directory specified
 optimizely-cms-cli config pull --output ./src/content-types
 
+# With output file specified (automatic single-file mode)
+optimizely-cms-cli config pull --output ./src/cms-types.ts
+
 # Group generated files by content type base type (page/, component/, section/, etc.)
 optimizely-cms-cli config pull --output ./src/types --group
 
@@ -129,6 +132,8 @@ optimizely-cms-cli config pull | grep -i "Article"
 # Include read-only system content types
 optimizely-cms-cli config pull --include-read-only
 ```
+
+> **Tip:** If `--output` ends with `.ts` or `.tsx`, the CLI automatically uses single-file mode and writes to that exact file path. For example, `--output ./src/cms-types.ts` creates a single file at `./src/cms-types.ts`.
 
 > **Note:** The command automatically detects when output is piped or redirected and outputs JSON without prompting. You can also explicitly use `--json` to force JSON output. The `--output` flag works in all environments, including CI/non-TTY contexts.
 

--- a/packages/optimizely-cms-cli/src/commands/config/pull.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/pull.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core';
-import { resolve } from 'node:path';
+import { resolve, dirname, basename } from 'node:path';
 import ora from 'ora';
 import chalk from 'chalk';
 import { input, select } from '@inquirer/prompts';
@@ -17,6 +17,8 @@ import {
 import { getRelevantPath, makeDirs, makeFile, makeFiles } from '../../utils/make.js';
 import { formatCounts, validateManifest } from '../../utils/general.js';
 import { filterOutBuiltinTypes } from '../../utils/mapping.js';
+
+const defaultOutput = './src/content-types';
 
 export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
   static override flags = {
@@ -203,20 +205,27 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
   }
 
   private async handleSingleFileOutput(
-    outputDir: string,
-    outputPath: string,
+    resolvedOutput: string,
+    providedOutput: string,
     manifest: Manifest,
+    hasProvidedFilename: boolean,
   ): Promise<void> {
     const spinner = ora('Generating file').start();
+    const outputDir = hasProvidedFilename ? dirname(resolvedOutput) : resolvedOutput;
+    const filePath =
+      hasProvidedFilename ? resolvedOutput : generateManifestFilePath(resolvedOutput);
+
     await mkdir(outputDir, { recursive: true });
 
     await makeFile({
-      path: generateManifestFilePath(outputDir),
+      path: filePath,
       content: generateManifestCode(manifest),
     });
 
     this.logManifestStats(manifest, spinner);
-    spinner.succeed(` Generated manifest.ts file in ${outputPath}`);
+    const fileName = hasProvidedFilename ? basename(resolvedOutput) : 'manifest.ts';
+    const displayLocation = hasProvidedFilename ? providedOutput : `in ${providedOutput}`;
+    spinner.succeed(` Generated ${fileName} file ${displayLocation}`);
   }
 
   private async handleIndividualOutput(
@@ -305,15 +314,26 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
       : 'group';
 
     // Prompt for output directory if not provided
-    const outputPath =
+    const providedOutput =
       flags.output ||
       (isInteractive ?
         await input({
           message: 'Where should the generated file(s) be saved?',
-          default: './src/content-types',
+          default: defaultOutput,
         })
-      : './src/content-types');
-    const outputDir = resolve(process.cwd(), outputPath);
+      : defaultOutput);
+    const resolvedOutput = resolve(process.cwd(), providedOutput);
+
+    // Check if user provided a file path (ends with .ts or .tsx)
+    const isForcedSingleFileMode = /\.tsx?$/.test(providedOutput);
+    const actualOutputType = isForcedSingleFileMode ? 'single-file' : outputType;
+
+    // Warn if conflicting flags are present
+    if (isForcedSingleFileMode && (flags.group || flags.individual)) {
+      this.warn(
+        'Flags --group and --individual are ignored when --output ends with .ts(x) (single-file mode)',
+      );
+    }
 
     const spinner = ora('Downloading configuration from CMS').start();
 
@@ -334,13 +354,18 @@ export default class ConfigPull extends BaseCommand<typeof ConfigPull> {
 
       spinner.succeed(' Downloaded configuration from CMS');
 
-      switch (outputType) {
+      switch (actualOutputType) {
         case 'single-file':
-          return this.handleSingleFileOutput(outputDir, outputPath, manifest);
+          return this.handleSingleFileOutput(
+            resolvedOutput,
+            providedOutput,
+            manifest,
+            isForcedSingleFileMode,
+          );
         case 'individual':
-          return this.handleIndividualOutput(outputDir, outputPath, manifest);
+          return this.handleIndividualOutput(resolvedOutput, providedOutput, manifest);
         default:
-          return this.handleGroupOutput(outputDir, outputPath, manifest);
+          return this.handleGroupOutput(resolvedOutput, providedOutput, manifest);
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/optimizely-cms-cli/src/tests/pull-command.test.ts
+++ b/packages/optimizely-cms-cli/src/tests/pull-command.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, mkdir, readdir, readFile, stat } from 'node:fs/promises';
+import { join, dirname, basename, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { makeFile } from '../utils/make.js';
+import { generateManifestCode, generateManifestFilePath } from '../utils/generate.js';
+import { Manifest } from '../utils/manifest.js';
+
+const mockManifest: Manifest = {
+  contentTypes: [
+    {
+      key: 'ArticlePage',
+      displayName: 'Article Page',
+      baseType: '_page',
+      isContract: false,
+      properties: {
+        heading: { type: 'string' },
+        body: { type: 'richText' },
+      },
+    },
+  ],
+  displayTemplates: [],
+};
+
+const createTestFile = async (
+  providedOutput: string,
+  assertions: (tempDir: string, resolvedOutput: string) => Promise<void>,
+) => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'cli-test-'));
+
+  try {
+    const resolvedOutput = resolve(tempDir, providedOutput);
+    const isSingleFile = /\.tsx?$/.test(providedOutput);
+    const outputDir = isSingleFile ? dirname(resolvedOutput) : resolvedOutput;
+    const filePath = isSingleFile ? resolvedOutput : generateManifestFilePath(resolvedOutput);
+
+    await mkdir(outputDir, { recursive: true });
+
+    await makeFile({
+      path: filePath,
+      content: generateManifestCode(mockManifest),
+    });
+
+    await assertions(tempDir, resolvedOutput);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+};
+
+describe('Pull command file output logic', () => {
+  it('should create file at exact path when output ends with .ts', async () => {
+    await createTestFile('./types.ts', async (tempDir, resolvedOutput) => {
+      const files = await readdir(tempDir);
+      expect(files).toContain('types.ts');
+
+      const stats = await stat(resolvedOutput);
+      expect(stats.isFile()).toBe(true);
+
+      const content = await readFile(resolvedOutput, 'utf-8');
+      expect(content).toContain('ArticlePage');
+    });
+  });
+
+  it('should create file with .tsx extension', async () => {
+    await createTestFile('./cms-types.tsx', async (tempDir, resolvedOutput) => {
+      const files = await readdir(tempDir);
+      expect(files).toContain('cms-types.tsx');
+
+      const stats = await stat(resolvedOutput);
+      expect(stats.isFile()).toBe(true);
+    });
+  });
+
+  it('should create manifest.ts in directory when path has no .ts extension', async () => {
+    await createTestFile('./types', async (tempDir, resolvedOutput) => {
+      const files = await readdir(resolve(tempDir, 'types'));
+      expect(files).toContain('manifest.ts');
+
+      const stats = await stat(resolvedOutput);
+      expect(stats.isDirectory()).toBe(true);
+    });
+  });
+
+  it('should create parent directories when using nested path with .ts', async () => {
+    await createTestFile('./src/cms/types.ts', async (tempDir, resolvedOutput) => {
+      const srcStats = await stat(resolve(tempDir, 'src'));
+      expect(srcStats.isDirectory()).toBe(true);
+
+      const cmsStats = await stat(resolve(tempDir, 'src', 'cms'));
+      expect(cmsStats.isDirectory()).toBe(true);
+
+      const fileStats = await stat(resolvedOutput);
+      expect(fileStats.isFile()).toBe(true);
+    });
+  });
+
+  it('should handle filename with multiple dots correctly', async () => {
+    await createTestFile('./my.content.types.ts', async (tempDir, resolvedOutput) => {
+      const fileName = basename(resolvedOutput);
+      expect(fileName).toBe('my.content.types.ts');
+
+      const files = await readdir(tempDir);
+      expect(files).toContain('my.content.types.ts');
+    });
+  });
+});


### PR DESCRIPTION
When `--output` has en extension (.ts or .tsx) enforce creation of a single file.