### PR TITLE
CMS-53656 Add re-exports for types needed in declaration file generation

### DIFF
--- a/packages/optimizely-cms-sdk/src/index.ts
+++ b/packages/optimizely-cms-sdk/src/index.ts
@@ -50,3 +50,21 @@ export { ContentProps } from './infer.js';
 
 // Dam assets
 export { damAssets } from './render/assets.js';
+
+// Re-export types needed for declaration file generation in consuming libraries
+export type {
+  AnyContentType,
+  BaseTypes,
+  ComponentContentType,
+  ContentType,
+  Contract,
+  ExperienceContentType,
+  FolderContentType,
+  MediaContentType,
+  MediaStringTypes,
+  PageContentType,
+  PermittedTypes,
+  PropertiesRecord,
+  SectionContentType,
+  SuppliedContractValues,
+} from './model/contentTypes.js';

--- a/packages/optimizely-cms-sdk/src/model/index.ts
+++ b/packages/optimizely-cms-sdk/src/model/index.ts
@@ -153,3 +153,21 @@ export {
   isContentTypeRegistered,
 } from './contentTypeRegistry.js';
 export { init as initDisplayTemplateRegistry } from './displayTemplateRegistry.js';
+
+// Re-export types needed for declaration file generation
+export type {
+  AnyContentType,
+  BaseTypes,
+  ComponentContentType,
+  ContentType,
+  Contract,
+  ExperienceContentType,
+  FolderContentType,
+  MediaContentType,
+  MediaStringTypes,
+  PageContentType,
+  PermittedTypes,
+  PropertiesRecord,
+  SectionContentType,
+  SuppliedContractValues,
+} from './contentTypes.js';


### PR DESCRIPTION
- Fix `TS2883` error by re-exporting types from API.
