### PR TITLE
Make Application Settings available to all pages and components.

### DIFF
--- a/docs/16-app-settings.md
+++ b/docs/16-app-settings.md
@@ -1,0 +1,182 @@
+# App Settings
+
+App settings let you load a single CMS content item once and make its data available to every component in the application — server components, client components, layout, and pages — without repeated fetching or prop drilling.
+
+## The problem it solves
+
+Many components need site-wide data that lives in the CMS: site name, logo URL, contact details, navigation config, analytics IDs, social links. Without this feature, each component either fetches this data itself (redundant CMS calls) or the data gets prop-drilled through every page route (tight coupling).
+
+## Architecture
+
+```
+CMS (settings item — located by path, content type, or key)
+        │
+        ▼
+getAppSettings()       ← unstable_cache (ISR — survives across requests)
+        │
+   ┌────┴──────────────────────────────────────────┐
+   │                                               │
+layout.tsx (server)                    AppSettingsProvider
+   └─ fetches once, wraps all children     └─ useAppSettings() in any client component
+                                              getAppSettings() in any server component
+```
+
+Settings are read-only. The data flows in one direction:
+```
+CMS → getAppSettings() → AppSettingsProvider → components (read only)
+```
+
+## Layer separation
+
+| Layer | What lives here |
+|---|---|
+| **SDK** (`@optimizely/cms-sdk`) | `AppSettingsProvider`, `useAppSettings` — generic React Context plumbing, no assumptions about content shape or CMS path |
+| **App** (`src/`) | `appSettings.ts` — source strategy, cache interval, field mapper. `getAppSettings.ts` — the cached fetch resolver. |
+
+## Source strategies
+
+Three mutually exclusive ways to locate the settings item in the CMS. Pick one in `src/appSettings.ts`:
+
+### By URL path
+Use when the settings item has a known URL in your CMS.
+
+```ts
+source: { by: 'path', path: '/global-settings/' }
+```
+
+### By content type
+Use when there is a single instance of a dedicated settings content type (e.g. `SiteSettings`). The fetch retrieves the first (and only) item of that type.
+
+```ts
+source: { by: 'contentType', contentType: 'SiteSettings' }
+```
+
+### By content key
+Use when you know the item's unique content key. Optionally scope to a locale.
+
+```ts
+source: { by: 'key', key: 'site-settings-root' }
+source: { by: 'key', key: 'site-settings-root', locale: 'en-us' }
+```
+
+TypeScript enforces that exactly one strategy is configured — the `SettingsSource` discriminated union prevents mixing properties from different strategies.
+
+## Setup
+
+### 1. Configure in `src/appSettings.ts`
+
+```ts
+export const appSettingsConfig = {
+  source: { by: 'path', path: '/global-settings/' } as SettingsSource,
+  revalidate: 3600,   // cache 1 hour; use 0 during development for always-fresh
+
+  mapper: (content) => ({
+    siteName:    content.siteName as string,
+    logoUrl:     (content.logo as any)?.url as string,
+    phone:       content.phone as string,
+    email:       content.email as string,
+    analyticsId: content.gaTrackingId as string,
+  }),
+};
+```
+
+Without a `mapper`, the full raw CMS content object is stored.
+
+### 2. Layout is already wired (template)
+
+```tsx
+// app/layout.tsx
+import { AppSettingsProvider } from '@optimizely/cms-sdk/react/client';
+import { getAppSettings } from '@/getAppSettings';
+
+export default async function RootLayout({ children }) {
+  const settings = await getAppSettings().catch(() => null);
+  return (
+    <html><body>
+      <AppSettingsProvider settings={settings}>
+        {children}
+      </AppSettingsProvider>
+    </body></html>
+  );
+}
+```
+
+`.catch(() => null)` ensures the layout never crashes if the CMS is unreachable.
+
+## Reading settings in components
+
+### Server components
+
+```ts
+import { getAppSettings } from '@/getAppSettings';
+
+export async function Footer() {
+  const settings = await getAppSettings();   // cache hit — no extra CMS call
+  return <footer>{settings?.phone} · {settings?.email}</footer>;
+}
+```
+
+### Client components
+
+```tsx
+'use client';
+import { useAppSettings } from '@optimizely/cms-sdk/react/client';
+
+export function Header() {
+  const settings = useAppSettings<{ siteName: string; logoUrl: string }>();
+  return <header><img src={settings?.logoUrl} alt={settings?.siteName} /></header>;
+}
+```
+
+## Caching behaviour
+
+| Scenario | Result |
+|---|---|
+| First request after deploy | CMS fetch occurs, result stored |
+| Subsequent requests within `revalidate` window | Served from cache — zero CMS calls |
+| After `revalidate` seconds | Stale cache served; re-fetch runs in background |
+| After CMS publish | Call `revalidateTag('app-settings')` |
+
+### Cache invalidation webhook
+
+```ts
+// app/api/revalidate/route.ts
+import { revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { secret, tag } = await req.json();
+  if (secret !== process.env.REVALIDATE_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  revalidateTag(tag ?? 'app-settings');
+  return NextResponse.json({ revalidated: true });
+}
+```
+
+## Typed wrapper (recommended)
+
+Create a typed wrapper once so every component gets full type safety with no casting:
+
+```ts
+// src/useSettings.ts
+'use client';
+import { useAppSettings } from '@optimizely/cms-sdk/react/client';
+
+export interface SiteSettings {
+  siteName: string;
+  logoUrl:  string;
+  phone:    string;
+  email:    string;
+}
+
+export function useSettings(): SiteSettings | null {
+  return useAppSettings<SiteSettings>();
+}
+```
+
+## When to use / not use
+
+**Use for:** site name, logo, tagline, contact info, social links, feature flags, analytics IDs — anything CMS-managed that applies to the whole site.
+
+**Do not use for:** data specific to one page (fetch in `page.tsx` instead), data that changes on every request (use `revalidate: 0`), large content trees (map only the scalar fields components need).

--- a/packages/optimizely-cms-sdk/src/index.ts
+++ b/packages/optimizely-cms-sdk/src/index.ts
@@ -45,6 +45,10 @@ export * as BuildConfig from './model/buildConfig.js';
 export * as DisplayTemplates from './model/displayTemplates.js';
 export * as Properties from './model/properties.js';
 
+// App settings — propagate CMS application-level settings to all components
+export { AppSettingsProvider, useAppSettings } from './react/client.js';
+export type { AppSettingsProviderProps } from './react/client.js';
+
 // Type inference and asset utilities
 export { ContentProps } from './infer.js';
 

--- a/packages/optimizely-cms-sdk/src/react/client.tsx
+++ b/packages/optimizely-cms-sdk/src/react/client.tsx
@@ -3,10 +3,74 @@ import {
   useState,
   useEffect,
   useRef,
+  createContext,
+  useContext,
   type ReactNode,
+  type ReactElement,
   type FunctionComponent,
   type PropsWithChildren,
 } from 'react';
+
+// ---------------------------------------------------------------------------
+// App Settings Context
+// ---------------------------------------------------------------------------
+
+const AppSettingsContext = createContext<Record<string, unknown> | null>(null);
+
+export interface AppSettingsProviderProps {
+  /** Serializable settings object returned by getAppSettings(). */
+  settings: Record<string, unknown> | null;
+  children: ReactNode;
+}
+
+/**
+ * Provides application-level CMS settings to all client components in the tree.
+ * Place in the root layout so every page and component can access settings.
+ *
+ * @example
+ * ```tsx
+ * // app/layout.tsx
+ * import { AppSettingsProvider } from '@optimizely/cms-sdk/react/client';
+ * import { getAppSettings } from '@/getAppSettings';
+ *
+ * export default async function RootLayout({ children }) {
+ *   const settings = await getAppSettings().catch(() => null);
+ *   return (
+ *     <html><body>
+ *       <AppSettingsProvider settings={settings}>{children}</AppSettingsProvider>
+ *     </body></html>
+ *   );
+ * }
+ * ```
+ */
+export function AppSettingsProvider({ settings, children }: AppSettingsProviderProps): ReactElement {
+  return (
+    <AppSettingsContext.Provider value={settings}>
+      {children}
+    </AppSettingsContext.Provider>
+  );
+}
+
+/**
+ * Returns application-level CMS settings in any client component.
+ * Returns null if AppSettingsProvider is not in the tree or settings failed to load.
+ *
+ * @example
+ * ```tsx
+ * 'use client';
+ * import { useAppSettings } from '@optimizely/cms-sdk/react/client';
+ *
+ * export function Header() {
+ *   const settings = useAppSettings<{ siteName: string; logoUrl: string }>();
+ *   return <header><img src={settings?.logoUrl} alt={settings?.siteName} /></header>;
+ * }
+ * ```
+ */
+export function useAppSettings<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(): T | null {
+  return useContext(AppSettingsContext) as T | null;
+}
 
 interface ContentSavedEvent {
   contentLink: string;

--- a/samples/nextjs-template/src/app/layout.tsx
+++ b/samples/nextjs-template/src/app/layout.tsx
@@ -32,6 +32,8 @@ import OfficeLocations, { OfficeContentType } from '@/components/OfficeLocations
 import Location, { LocationContentType } from '@/components/Location';
 import BlankExperience from '@/components/BlankExperience';
 import FAQ, { FAQContentType } from '@/components/FAQ';
+import { AppSettingsProvider } from '@optimizely/cms-sdk/react/client';
+import { getAppSettings } from '@/getAppSettings';
 
 config({
   apiKey: process.env.OPTIMIZELY_GRAPH_SINGLE_KEY || "your api key here",
@@ -109,14 +111,19 @@ const sansFont = Inter({
   subsets: ['latin'],
 });
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const settings = await getAppSettings().catch(() => null);
   return (
     <html lang='en' className={[serifFont.variable, sansFont.variable].join(' ')}>
-      <body>{children}</body>
+      <body>
+        <AppSettingsProvider settings={settings}>
+          {children}
+        </AppSettingsProvider>
+      </body>
     </html>
   );
 }

--- a/samples/nextjs-template/src/appSettings.ts
+++ b/samples/nextjs-template/src/appSettings.ts
@@ -1,0 +1,66 @@
+/**
+ * Application-level settings configuration.
+ *
+ * Choose ONE source strategy for loading the settings item from CMS:
+ *
+ *   by: 'path'         — fetch by URL path  (e.g. '/global-settings/')
+ *   by: 'contentType'  — fetch by content type name (single instance)
+ *   by: 'key'          — fetch by content key, with optional locale
+ *
+ * ─── Accessing settings ───────────────────────────────────────────────────
+ *
+ * Server components:
+ *   import { getAppSettings } from '@/getAppSettings';
+ *   const settings = await getAppSettings();
+ *
+ * Client components:
+ *   'use client';
+ *   import { useAppSettings } from '@optimizely/cms-sdk/react/client';
+ *   const settings = useAppSettings<{ siteName: string }>();
+ *
+ * ─── Cache invalidation ───────────────────────────────────────────────────
+ * After a CMS publish, call revalidateTag('app-settings') to purge the cache.
+ */
+
+/** Load settings by URL path — use when the settings item has a known URL */
+type ByPath = { by: 'path'; path: string };
+
+/** Load settings by content type name — use when there is a single instance of this type */
+type ByContentType = { by: 'contentType'; contentType: string };
+
+/** Load settings by content key — use when you know the item's unique key */
+type ByKey = { by: 'key'; key: string; locale?: string };
+
+export type SettingsSource = ByPath | ByContentType | ByKey;
+
+export const appSettingsConfig = {
+  /**
+   * How to locate the settings item in the CMS.
+   * Pick one strategy and delete the others.
+   */
+  source: { by: 'path', path: '/global-settings/' } as SettingsSource,
+  // source: { by: 'contentType', contentType: 'SiteSettings' } as SettingsSource,
+  // source: { by: 'key', key: 'site-settings-root', locale: 'en-us' } as SettingsSource,
+
+  /**
+   * ISR revalidation interval in seconds.
+   * 0 = always fresh (useful during development).
+   */
+  revalidate: 3600,
+
+  /**
+   * Optional mapper — extract only what your app needs.
+   * Without a mapper, the full CMS content object is stored.
+   *
+   * mapper: (content) => ({
+   *   siteName:    content.siteName as string,
+   *   logoUrl:     (content.logo as any)?.url as string,
+   *   phone:       content.phone as string,
+   *   email:       content.email as string,
+   *   analyticsId: content.gaTrackingId as string,
+   * }),
+   */
+  mapper: undefined as
+    | ((content: Record<string, unknown>) => Record<string, unknown>)
+    | undefined,
+};

--- a/samples/nextjs-template/src/getAppSettings.ts
+++ b/samples/nextjs-template/src/getAppSettings.ts
@@ -1,0 +1,72 @@
+import { unstable_cache } from 'next/cache';
+import { getClient } from '@optimizely/cms-sdk';
+import { appSettingsConfig, type SettingsSource } from '@/appSettings';
+
+/**
+ * Resolves the CMS content for the configured settings source.
+ * Supports three strategies: path, contentType, key.
+ */
+async function fetchSettingsContent(
+  source: SettingsSource,
+): Promise<Record<string, unknown> | null> {
+  const client = getClient();
+
+  if (source.by === 'path') {
+    const result = await client.getContentByPath(source.path);
+    return (result[0] as Record<string, unknown>) ?? null;
+  }
+
+  if (source.by === 'contentType') {
+    const query = `
+      query GetSettingsByType($type: String!) {
+        _Content(where: { _metadata: { types: { eq: $type } } }, limit: 1) {
+          items { _metadata { key url { default } types } }
+        }
+      }
+    `;
+    const data = await client.request(query, { type: source.contentType }) as { _Content: { items: Record<string, unknown>[] } };
+    return (data._Content?.items?.[0] as Record<string, unknown>) ?? null;
+  }
+
+  if (source.by === 'key') {
+    const query = `
+      query GetSettingsByKey($key: String!, $locale: [Locales]) {
+        _Content(where: { _metadata: { key: { eq: $key } } }, locale: $locale, limit: 1) {
+          items { _metadata { key url { default } types } }
+        }
+      }
+    `;
+    const data = await client.request(query, { key: source.key, locale: source.locale ?? null }) as { _Content: { items: Record<string, unknown>[] } };
+    return (data._Content?.items?.[0] as Record<string, unknown>) ?? null;
+  }
+
+  return null;
+}
+
+/**
+ * Fetches app-level CMS settings with ISR caching.
+ *
+ * The result is cached across requests for appSettingsConfig.revalidate seconds.
+ * Stale content is served immediately while a background re-fetch updates the cache.
+ *
+ * Cache tag: 'app-settings'
+ * Invalidate with: revalidateTag('app-settings')  (e.g. from a publish webhook)
+ *
+ * Server components:
+ *   const settings = await getAppSettings();
+ *
+ * layout.tsx (feeds client components via AppSettingsProvider):
+ *   const settings = await getAppSettings().catch(() => null);
+ */
+export const getAppSettings = unstable_cache(
+  async (): Promise<Record<string, unknown> | null> => {
+    const raw = await fetchSettingsContent(appSettingsConfig.source);
+    if (!raw) return null;
+    return appSettingsConfig.mapper ? appSettingsConfig.mapper(raw) : raw;
+  },
+  ['app-settings'],
+  {
+    revalidate: appSettingsConfig.revalidate,
+    tags: ['app-settings'],
+  },
+);


### PR DESCRIPTION
## Summary

Components across the app frequently need site-wide data stored in the CMS
(site name, logo, contact details, analytics IDs, feature flags). Without this
feature, each component either fetches this independently (redundant CMS calls)
or the data is prop-drilled through every page route.

This PR introduces **app settings** — a pattern that loads a single CMS content
item once per cache cycle and makes it available to every server and client
component in the application without repeated fetching or prop drilling.

Full details: [`docs/16-app-settings.md`](docs/16-app-settings.md)
