### PR TITLE
CMS-53673 Add language support in configuration and sync locales with CMS

### DIFF
--- a/.changeset/silly-maps-tie.md
+++ b/.changeset/silly-maps-tie.md
@@ -1,0 +1,6 @@
+---
+'@optimizely/cms-cli': minor
+'@optimizely/cms-sdk': minor
+---
+
+Add support for language/locale in build config

--- a/docs/4-create-content.md
+++ b/docs/4-create-content.md
@@ -87,6 +87,20 @@ The CLI enforces this dependency chain during `config push`: contentTypes must e
 
 > Note: The programmatic (config-based) approach does not currently support updating applications. To update an application, you must first delete the existing application and its start page content from the CMS, then run the push command again.
 
+### Locales
+
+Add locales (language branches) to your configuration:
+
+```javascript
+export default buildConfig({
+  components: ['./src/components/**/*.tsx'],
+  locale: ['en-US', 'sv-SE', 'de', 'fi'],  // IETF BCP-47 tags
+  // ... other config
+});
+```
+
+Running `config push` creates missing locales and enables existing ones. Locales already enabled remain unchanged.
+
 ## Step 3. Change the "home" URL
 
 1. Go to your CMS &rarr; Content &rarr; Home

--- a/packages/optimizely-cms-cli/src/commands/config/push.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/push.ts
@@ -59,7 +59,7 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
 
     const configPath = pathToFileURL(configFilePath).href;
 
-    const { componentPaths, propertyGroups, applications, content, languages } =
+    const { componentPaths, propertyGroups, applications, content, locale } =
       await readFromPath(configPath);
 
     // Validate components field
@@ -183,8 +183,8 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
     const data = response.data;
 
     // Sync locales from config
-    if (languages && Array.isArray(languages) && languages.length > 0) {
-      await syncLocales(languages, restClient);
+    if (locale && Array.isArray(locale) && locale.length > 0) {
+      await syncLocales(locale, restClient);
     }
 
     // Check and ensure applications (skips if all exist)

--- a/packages/optimizely-cms-cli/src/commands/config/push.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/push.ts
@@ -17,6 +17,7 @@ import { pathToFileURL } from 'node:url';
 import { constants } from 'node:fs';
 import { translateErrorMessage } from '../../utils/errors.js';
 import { contractToManifest } from '../../utils/mapping.js';
+import { syncLocales } from '../../service/localeService.js';
 
 export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
   static override args = {
@@ -58,7 +59,7 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
 
     const configPath = pathToFileURL(configFilePath).href;
 
-    const { componentPaths, propertyGroups, applications, content } =
+    const { componentPaths, propertyGroups, applications, content, languages } =
       await readFromPath(configPath);
 
     // Validate components field
@@ -180,6 +181,11 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
     }
 
     const data = response.data;
+
+    // Sync locales from config
+    if (languages && Array.isArray(languages) && languages.length > 0) {
+      await syncLocales(languages, restClient);
+    }
 
     // Check and ensure applications (skips if all exist)
     await checkApplications(validatedApplications, content, flags.host);

--- a/packages/optimizely-cms-cli/src/service/localeService.ts
+++ b/packages/optimizely-cms-cli/src/service/localeService.ts
@@ -22,10 +22,10 @@ const deriveDisplayName = (key: string): string => {
  * Syncs locales from buildConfig to CMS via REST API
  */
 export async function syncLocales(
-  languages: string[],
+  locale: string[],
   restClient: ApiClient,
 ): Promise<void> {
-  if (!languages || !Array.isArray(languages) || languages.length === 0) {
+  if (!locale || !Array.isArray(locale) || locale.length === 0) {
     return;
   }
 
@@ -37,7 +37,9 @@ export async function syncLocales(
     spinner.fail(chalk.red('Failed to fetch existing locales'));
     const error = listResponse.error;
     console.error(
-      chalk.dim(`${error.status || ''} ${error.detail || error.title || 'Unknown error'}`),
+      chalk.dim(
+        `${error.status || ''} ${error.detail || error.title || 'Unknown error'}`,
+      ),
     );
     return;
   }
@@ -46,12 +48,12 @@ export async function syncLocales(
   const existingKeys = new Set(existingLocales.map(l => l.key));
 
   // Categorize locales
-  const toCreate = languages.filter(lang => !existingKeys.has(lang));
-  const toEnable = languages.filter(lang => {
+  const toCreate = locale.filter(lang => !existingKeys.has(lang));
+  const toEnable = locale.filter(lang => {
     const existing = existingLocales.find(l => l.key === lang);
     return existing && !existing.isEnabled;
   });
-  const alreadyEnabled = languages.filter(lang => {
+  const alreadyEnabled = locale.filter(lang => {
     const existing = existingLocales.find(l => l.key === lang);
     return existing && existing.isEnabled;
   });
@@ -67,7 +69,7 @@ export async function syncLocales(
 
     const createResponse = await restClient.POST('/locales', {
       body: newLocale as any,
-      bodySerializer: (body) => JSON.stringify(body),
+      bodySerializer: body => JSON.stringify(body),
     });
 
     if (createResponse.error) {
@@ -93,7 +95,7 @@ export async function syncLocales(
     const patchResponse = await restClient.PATCH(`/locales/{key}`, {
       params: { path: { key: lang } },
       body: { isEnabled: true } as any,
-      bodySerializer: (body) => JSON.stringify(body),
+      bodySerializer: body => JSON.stringify(body),
       headers: {
         'content-type': 'application/merge-patch+json',
       },

--- a/packages/optimizely-cms-cli/src/service/localeService.ts
+++ b/packages/optimizely-cms-cli/src/service/localeService.ts
@@ -1,0 +1,126 @@
+import ora from 'ora';
+import chalk from 'chalk';
+import type { Client } from 'openapi-fetch';
+import type { paths } from './apiSchema/openapi-schema-types.js';
+
+type ApiClient = Client<paths>;
+type Locale = paths['/locales']['post']['requestBody']['content']['application/json'];
+
+/**
+ * Derives display name from locale key (e.g., "en-US" -> "English (United States)")
+ */
+const deriveDisplayName = (key: string): string => {
+  try {
+    const locale = new Intl.DisplayNames(['en'], { type: 'language' });
+    return locale.of(key) || key;
+  } catch {
+    return key;
+  }
+};
+
+/**
+ * Syncs locales from buildConfig to CMS via REST API
+ */
+export async function syncLocales(
+  languages: string[],
+  restClient: ApiClient,
+): Promise<void> {
+  if (!languages || !Array.isArray(languages) || languages.length === 0) {
+    return;
+  }
+
+  const spinner = ora('Syncing locales').start();
+
+  // Fetch existing locales
+  const listResponse = await restClient.GET('/locales');
+  if (listResponse.error) {
+    spinner.fail(chalk.red('Failed to fetch existing locales'));
+    const error = listResponse.error;
+    console.error(
+      chalk.dim(`${error.status || ''} ${error.detail || error.title || 'Unknown error'}`),
+    );
+    return;
+  }
+
+  const existingLocales = listResponse.data?.items || [];
+  const existingKeys = new Set(existingLocales.map(l => l.key));
+
+  // Categorize locales
+  const toCreate = languages.filter(lang => !existingKeys.has(lang));
+  const toEnable = languages.filter(lang => {
+    const existing = existingLocales.find(l => l.key === lang);
+    return existing && !existing.isEnabled;
+  });
+  const alreadyEnabled = languages.filter(lang => {
+    const existing = existingLocales.find(l => l.key === lang);
+    return existing && existing.isEnabled;
+  });
+
+  let createdCount = 0;
+  for (const lang of toCreate) {
+    const newLocale: Locale = {
+      key: lang,
+      displayName: deriveDisplayName(lang),
+      isEnabled: true,
+      routeSegment: lang.toLowerCase(),
+    };
+
+    const createResponse = await restClient.POST('/locales', {
+      body: newLocale as any,
+      bodySerializer: (body) => JSON.stringify(body),
+    });
+
+    if (createResponse.error) {
+      const error = createResponse.error;
+      spinner.warn(
+        chalk.yellow(
+          `Failed to create locale ${lang}: ${error.detail || error.title || 'Unknown error'}`,
+        ),
+      );
+      if (error.errors?.length) {
+        error.errors.forEach(err => {
+          console.log(chalk.dim(`  - ${err.detail} (field: ${err.field})`));
+        });
+      }
+    } else {
+      createdCount++;
+    }
+  }
+
+  // Enable disabled locales that are in config
+  let enabledCount = 0;
+  for (const lang of toEnable) {
+    const patchResponse = await restClient.PATCH(`/locales/{key}`, {
+      params: { path: { key: lang } },
+      body: { isEnabled: true } as any,
+      bodySerializer: (body) => JSON.stringify(body),
+      headers: {
+        'content-type': 'application/merge-patch+json',
+      },
+    });
+
+    if (patchResponse.error) {
+      const error = patchResponse.error;
+      spinner.warn(
+        chalk.yellow(
+          `Failed to enable locale ${lang}: ${error.detail || error.title || 'Unknown error'}`,
+        ),
+      );
+      if (error.errors?.length) {
+        error.errors.forEach(err => {
+          console.log(chalk.dim(`  - ${err.detail} (field: ${err.field})`));
+        });
+      }
+    } else {
+      enabledCount++;
+    }
+  }
+
+  const failed = toCreate.length - createdCount + toEnable.length - enabledCount;
+
+  spinner.succeed(
+    chalk.green(
+      `Locales synced: ${createdCount} created, ${enabledCount} enabled, ${alreadyEnabled.length} unchanged${failed > 0 ? `, ${failed} failed` : ''}`,
+    ),
+  );
+}

--- a/packages/optimizely-cms-cli/src/service/utils.ts
+++ b/packages/optimizely-cms-cli/src/service/utils.ts
@@ -237,6 +237,7 @@ export const readFromPath = async (configPath: string) => {
       propertyGroups: config.default['propertyGroups'],
       applications: config.default['applications'],
       content: config.default['content'],
+      languages: config.default['languages'],
     };
   } catch (error) {
     console.error(chalk.red('Failed to read configuration file'));

--- a/packages/optimizely-cms-cli/src/service/utils.ts
+++ b/packages/optimizely-cms-cli/src/service/utils.ts
@@ -237,7 +237,7 @@ export const readFromPath = async (configPath: string) => {
       propertyGroups: config.default['propertyGroups'],
       applications: config.default['applications'],
       content: config.default['content'],
-      languages: config.default['languages'],
+      locale: config.default['locale'],
     };
   } catch (error) {
     console.error(chalk.red('Failed to read configuration file'));

--- a/packages/optimizely-cms-sdk/src/model/buildConfig.ts
+++ b/packages/optimizely-cms-sdk/src/model/buildConfig.ts
@@ -59,6 +59,7 @@ export type ContentType = {
 
 export type BuildConfig = {
   components: string[];
+  languages: string[];
   propertyGroups: Array<PropertyGroupType>;
   applications?: Array<ApplicationsType>;
   content?: Array<ContentType>;

--- a/packages/optimizely-cms-sdk/src/model/buildConfig.ts
+++ b/packages/optimizely-cms-sdk/src/model/buildConfig.ts
@@ -59,7 +59,7 @@ export type ContentType = {
 
 export type BuildConfig = {
   components: string[];
-  languages: string[];
+  locale: string[];
   propertyGroups: Array<PropertyGroupType>;
   applications?: Array<ApplicationsType>;
   content?: Array<ContentType>;

--- a/templates/alloy/optimizely.config.mjs
+++ b/templates/alloy/optimizely.config.mjs
@@ -6,7 +6,7 @@ export default buildConfig({
     './src/components/**/*.tsx',
     './src/components/contracts/*.ts',
   ],
-  languages: ['fi', 'de', 'sp'],
+  locale: ['fi', 'de', 'sp'],
   propertyGroups: [
     {
       key: 'SEO',

--- a/templates/alloy/optimizely.config.mjs
+++ b/templates/alloy/optimizely.config.mjs
@@ -6,6 +6,7 @@ export default buildConfig({
     './src/components/**/*.tsx',
     './src/components/contracts/*.ts',
   ],
+  languages: ['fi', 'de', 'sp'],
   propertyGroups: [
     {
       key: 'SEO',


### PR DESCRIPTION
- Add support to language/locale creation and enable available ones.
- Add service for locale using the open-api schema.
- Use cli's push command for syncing locale.