### PR TITLE
CMS-53709 Fix stride images

### DIFF
--- a/templates/stride/README.md
+++ b/templates/stride/README.md
@@ -13,11 +13,11 @@ You need a CMS instance with Graph installed. Both local and SaaS instances are 
 1. Log in to your Optimizely CMS admin interface.
 2. Navigate to **Settings** → **API Keys**.
 3. Create a new API key.
-5. Navigate to **Settings** → **Set Access Rights**.
-6. Ensure the root is selected and **Apply settings for all subitems** is checked.
-7. Add full permissions for the API key.
-8. Save access rights.
-4. Create a copy of `.env.example` and rename it to `.env`, then fill out all the environment variables.
+4. Navigate to **Settings** → **Set Access Rights**.
+5. Ensure the root is selected and **Apply settings for all subitems** is checked.
+6. Add full permissions for the API key.
+7. Save access rights.
+8. Create a copy of `.env.example` and rename it to `.env`, then fill out all the environment variables.
 
 Sync all configuration to the CMS:
 
@@ -56,3 +56,5 @@ bun dev
 ```
 
 Open [https://localhost:3000](https://localhost:3000) with your browser to see the result.
+
+> Note: If images are not showing up in the Stride template, it is often caused by browser extensions blocking them. Try disabling extensions that may interfere with page content, such as Ghostery.

--- a/templates/stride/components/elements/Image.tsx
+++ b/templates/stride/components/elements/Image.tsx
@@ -32,7 +32,7 @@ export default function Image({ content }: ImageComponentProps) {
       <img
         src={content.image?.url.default ?? ''}
         alt={content.alternativeText ?? ''}
-        className='object-cover object-top aspect-square'
+        className='mx-auto'
       />
     </CmsField>
   );

--- a/templates/stride/components/sections/Hero.tsx
+++ b/templates/stride/components/sections/Hero.tsx
@@ -57,7 +57,7 @@ function RowWrapper({ children, node }: StructureContainerProps) {
   return (
     <div
       className={cn(
-        'relative z-10  container px-5 mx-auto md:flex gap-12 items-center py-20',
+        'h-[90vh] max-h-[900px] relative z-10  container px-5 mx-auto md:flex gap-12 items-center py-20',
         verticalSpacing,
       )}
       {...pa(node)}
@@ -69,28 +69,33 @@ function RowWrapper({ children, node }: StructureContainerProps) {
 
 function ComponentWrapper({ children, node }: ComponentContainerProps) {
   const { pa } = getPreviewUtils(node);
-  {
-    /* 
-    TODO: Hack to flow buttons. Preferrably we should be able to add the attributes directly
-    to the component ala 'asChild' so this element is not needed.
-    */
-  }
+
   if (node.type === 'ButtonElement') {
     return (
       <span className='pe-2' {...pa(node)}>
         {children}
       </span>
     );
-  } else {
-    return <div {...pa(node)}>{children}</div>;
   }
+
+  if (node.type === 'ImageElement') {
+    return (
+      <div className='flex items-center mt-[14rem]' {...pa(node)}>
+        {children}
+      </div>
+    );
+  }
+
+  return <>{children}</>;
 }
+
+// Placeholder solution, while _section related issues remain
+const defaultVideoSrc =
+  'https://cdn.midjourney.com/video/12166248-0ad6-4ab9-a545-022e30eef2ee/3.mp4';
 
 export default function Hero({ content, displaySettings }: HeroSectionProps) {
   const { pa } = getPreviewUtils(content);
-
   const width = widthStyles[displaySettings?.width ?? 'default'];
-
   const fadeOut =
     displaySettings?.fadeOut ?
       ' -mb-20 [mask-image:linear-gradient(#000_60%,transparent_70%)]'
@@ -99,27 +104,15 @@ export default function Hero({ content, displaySettings }: HeroSectionProps) {
   return (
     <section className={cn('p-1 pt-0', width, fadeOut)} {...pa(content)}>
       <div className='bg-cover bg-center relative bg-no-repeat rounded-lg overflow-x-clip box-border'>
-        <CmsField content={content} field={c => c.video}>
+        <CmsField content={content} field={c => c.video || defaultVideoSrc}>
           <video
-            src={content.video?.url.default ?? ''}
+            src={content.video?.url.default ?? defaultVideoSrc}
             autoPlay
             loop
             muted
             className='md:opacity-90 opacity-50 absolute inset-0 w-full h-full object-cover rounded-lg'
           />
         </CmsField>
-
-        {/* TODO: Remove this video when we've fixed the issue with missing section fragments. */}
-        <video
-          src={
-            content.video?.url.default ??
-            'https://cdn.midjourney.com/video/12166248-0ad6-4ab9-a545-022e30eef2ee/3.mp4'
-          }
-          autoPlay
-          loop
-          muted
-          className='md:opacity-90 opacity-50 absolute inset-0 w-full h-full object-cover rounded-lg'
-        />
 
         <OptimizelyGridSection
           nodes={content.nodes}

--- a/templates/stride/components/sections/Hero.tsx
+++ b/templates/stride/components/sections/Hero.tsx
@@ -80,7 +80,7 @@ function ComponentWrapper({ children, node }: ComponentContainerProps) {
 
   if (node.type === 'ImageElement') {
     return (
-      <div className='flex items-center mt-[14rem]' {...pa(node)}>
+      <div className='flex items-center mt-[18rem] invisible md:visible' {...pa(node)}>
         {children}
       </div>
     );


### PR DESCRIPTION
 - Fix images clipping
 - Add note for missing images due to extensions
 - Fix sizing for video

The src for the video is still using the default string video source, due to the general issues related to the _section type.