### PR TITLE
CMS-54088 contentType typing

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/__test__/convertProperty.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/convertProperty.test.ts
@@ -28,9 +28,9 @@ describe('createFragment > Fragment threshold warning', () => {
     properties: {
       contentArea: {
         type: 'content',
+        restrictedTypes: [],
       },
     },
-    compositionBehaviors: ['sectionEnabled'],
   });
 
   beforeAll(() => {

--- a/packages/optimizely-cms-sdk/src/graph/__test__/createQuery.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/createQuery.test.ts
@@ -424,7 +424,7 @@ describe('createFragment() with self references', () => {
       key: 'r1',
       displayName: 'R1',
       baseType: '_component',
-      properties: { p1: { type: 'content' } },
+      properties: { p1: { type: 'content', restrictedTypes: [] } },
     });
 
     initContentTypeRegistry([r1]);

--- a/packages/optimizely-cms-sdk/src/graph/__test__/createQueryDAM.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/createQueryDAM.test.ts
@@ -13,7 +13,7 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       displayName: 'CT1',
       baseType: '_page',
       properties: {
-        image: { type: 'contentReference' },
+        image: { type: 'contentReference', allowedTypes: ['*'] },
       },
     });
     initContentTypeRegistry([ct1]);
@@ -54,7 +54,7 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       displayName: 'CT1',
       baseType: '_page',
       properties: {
-        image: { type: 'contentReference' },
+        image: { type: 'contentReference', allowedTypes: ['*'] },
       },
     });
     initContentTypeRegistry([ct1]);
@@ -96,7 +96,7 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       displayName: 'CT1',
       baseType: '_page',
       properties: {
-        images: { type: 'array', items: { type: 'contentReference' } },
+        images: { type: 'array', items: { type: 'contentReference', allowedTypes: ['*'] } },
       },
     });
     initContentTypeRegistry([ct1]);
@@ -129,7 +129,7 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       displayName: 'CT1',
       baseType: '_page',
       properties: {
-        images: { type: 'array', items: { type: 'contentReference' } },
+        images: { type: 'array', items: { type: 'contentReference', allowedTypes: ['*'] } },
       },
     });
     initContentTypeRegistry([ct1]);
@@ -165,7 +165,7 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       displayName: 'CTBlock',
       baseType: '_component',
       properties: {
-        image: { type: 'contentReference' },
+        image: { type: 'contentReference', allowedTypes: ['*'] },
       },
     });
     const ct1 = contentType({
@@ -219,7 +219,7 @@ describe('createFragment() with damEnabled for contentReference properties', () 
       displayName: 'CTRef',
       baseType: '_component',
       properties: {
-        image: { type: 'contentReference' },
+        image: { type: 'contentReference', allowedTypes: ['*'] },
       },
     });
     const ct1 = contentType({
@@ -342,7 +342,7 @@ describe('createSingleContentQuery() with damEnabled', () => {
       displayName: 'CT1',
       baseType: '_page',
       properties: {
-        image: { type: 'contentReference' },
+        image: { type: 'contentReference', allowedTypes: ['*'] },
       },
     });
     initContentTypeRegistry([ct1]);
@@ -360,7 +360,7 @@ describe('createSingleContentQuery() with damEnabled', () => {
       displayName: 'CT1',
       baseType: '_page',
       properties: {
-        image: { type: 'contentReference' },
+        image: { type: 'contentReference', allowedTypes: ['*'] },
       },
     });
     initContentTypeRegistry([ct1]);
@@ -384,7 +384,7 @@ describe('createMultipleContentQuery() with damEnabled', () => {
       displayName: 'CT1',
       baseType: '_page',
       properties: {
-        image: { type: 'contentReference' },
+        image: { type: 'contentReference', allowedTypes: ['*'] },
       },
     });
     initContentTypeRegistry([ct1]);
@@ -401,7 +401,7 @@ describe('createMultipleContentQuery() with damEnabled', () => {
       displayName: 'CT1',
       baseType: '_page',
       properties: {
-        image: { type: 'contentReference' },
+        image: { type: 'contentReference', allowedTypes: ['*'] },
       },
     });
     initContentTypeRegistry([ct1]);

--- a/packages/optimizely-cms-sdk/src/infer.test-d.ts
+++ b/packages/optimizely-cms-sdk/src/infer.test-d.ts
@@ -28,7 +28,7 @@ test('ContentProps works for basic properties', () => {
       body: { type: 'richText' },
       price: { type: 'float' },
       units: { type: 'integer' },
-      image: { type: 'contentReference' },
+      image: { type: 'contentReference', allowedTypes: ['*'] },
     },
   });
 
@@ -55,7 +55,7 @@ test('ContentProps works for array properties', () => {
       body: { type: 'array', items: { type: 'richText' } },
       price: { type: 'array', items: { type: 'float' } },
       units: { type: 'array', items: { type: 'integer' } },
-      image: { type: 'array', items: { type: 'contentReference' } },
+      image: { type: 'array', items: { type: 'contentReference', allowedTypes: ['*'] } },
     },
   });
 
@@ -74,7 +74,7 @@ test('ContentProps works for component properties', () => {
     displayName: 'Hero',
     baseType: '_component',
     properties: {
-      image: { type: 'contentReference' },
+      image: { type: 'contentReference', allowedTypes: ['*'] },
     },
   });
 

--- a/packages/optimizely-cms-sdk/src/model/__test__/restrictions.test-d.ts
+++ b/packages/optimizely-cms-sdk/src/model/__test__/restrictions.test-d.ts
@@ -1,0 +1,122 @@
+import { test } from 'vitest';
+import { contentType, contract } from '../index.js';
+
+test('contract cannot have baseType field', () => {
+  contract({
+    key: 'test',
+    displayName: 'Test',
+    // @ts-expect-error - baseType is never allowed on contracts
+    baseType: '_page',
+  });
+});
+
+test('nested arrays are prevented', () => {
+  contentType({
+    key: 'page',
+    displayName: 'Page',
+    baseType: '_page',
+    properties: {
+      nested: {
+        type: 'array',
+        items: {
+          // @ts-expect-error - nested arrays not allowed, inner type cannot be 'array'
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    },
+  });
+});
+
+test('component property requires contentType field', () => {
+  const Hero = contentType({
+    key: 'hero',
+    displayName: 'Hero',
+    baseType: '_component',
+  });
+
+  contentType({
+    key: 'page',
+    displayName: 'Page',
+    baseType: '_page',
+    properties: {
+      hero: {
+        type: 'component',
+        contentType: Hero,
+      },
+    },
+  });
+
+  contentType({
+    key: 'page',
+    displayName: 'Page',
+    baseType: '_page',
+    properties: {
+      // @ts-expect-error - contentType field is required for component properties
+      hero: {
+        type: 'component',
+      },
+    },
+  });
+});
+
+test('compositionBehaviors allowed on component type', () => {
+  contentType({
+    key: 'component',
+    displayName: 'Component',
+    baseType: '_component',
+    compositionBehaviors: ['sectionEnabled', 'elementEnabled'],
+  });
+});
+
+test('content/contentReference require allowedTypes or restrictedTypes', () => {
+  contentType({
+    key: 'page',
+    displayName: 'Page',
+    baseType: '_page',
+    properties: {
+      // @ts-expect-error - contentReference requires either allowedTypes or restrictedTypes
+      ref: { type: 'contentReference' },
+    },
+  });
+
+  contentType({
+    key: 'page',
+    displayName: 'Page',
+    baseType: '_page',
+    properties: {
+      // @ts-expect-error - content requires either allowedTypes or restrictedTypes
+      area: { type: 'content' },
+    },
+  });
+
+  // ✅ Valid with allowedTypes
+  contentType({
+    key: 'page',
+    displayName: 'Page',
+    baseType: '_page',
+    properties: {
+      ref: { type: 'contentReference', allowedTypes: ['*'] },
+    },
+  });
+
+  // ✅ Valid with restrictedTypes
+  contentType({
+    key: 'page',
+    displayName: 'Page',
+    baseType: '_page',
+    properties: {
+      area: { type: 'content', restrictedTypes: [] },
+    },
+  });
+
+  // ✅ Valid with both
+  contentType({
+    key: 'page',
+    displayName: 'Page',
+    baseType: '_page',
+    properties: {
+      ref: { type: 'contentReference', allowedTypes: ['_component'], restrictedTypes: ['other'] },
+    },
+  });
+});

--- a/packages/optimizely-cms-sdk/src/model/__test__/restrictions.test-d.ts
+++ b/packages/optimizely-cms-sdk/src/model/__test__/restrictions.test-d.ts
@@ -90,7 +90,7 @@ test('content/contentReference require allowedTypes or restrictedTypes', () => {
     },
   });
 
-  // ✅ Valid with allowedTypes
+  // Valid with allowedTypes
   contentType({
     key: 'page',
     displayName: 'Page',
@@ -100,7 +100,7 @@ test('content/contentReference require allowedTypes or restrictedTypes', () => {
     },
   });
 
-  // ✅ Valid with restrictedTypes
+  // Valid with restrictedTypes
   contentType({
     key: 'page',
     displayName: 'Page',
@@ -110,7 +110,7 @@ test('content/contentReference require allowedTypes or restrictedTypes', () => {
     },
   });
 
-  // ✅ Valid with both
+  // Valid with both
   contentType({
     key: 'page',
     displayName: 'Page',

--- a/packages/optimizely-cms-sdk/src/model/contentTypes.ts
+++ b/packages/optimizely-cms-sdk/src/model/contentTypes.ts
@@ -67,8 +67,11 @@ type MergedPropertiesType<T extends AnyContentType> = ('extends' extends keyof T
 : {}) &
   ('properties' extends keyof T ? T['properties'] : {});
 
+/** Utility type for content types that don't support composition behaviors */
+type SkipCompositionBehaviors<T> = Omit<T, 'compositionBehaviors'>;
+
 /** Represents the Page type  in CMS */
-export type PageContentType = Omit<
+export type PageContentType = SkipCompositionBehaviors<
   BaseContentType & {
     baseType: '_page';
     mayContainTypes?: Array<
@@ -76,12 +79,11 @@ export type PageContentType = Omit<
       | '_self'
       | string
     >;
-  },
-  'compositionBehaviors'
+  }
 >;
 
 /** Represents the Experience type  in CMS */
-export type ExperienceContentType = Omit<
+export type ExperienceContentType = SkipCompositionBehaviors<
   BaseContentType & {
     baseType: '_experience';
     mayContainTypes?: Array<
@@ -89,17 +91,15 @@ export type ExperienceContentType = Omit<
       | '_self'
       | string
     >;
-  },
-  'compositionBehaviors'
+  }
 >;
 
 /** Represents the Folder (Used in the asset panel to organizing content and not in Graph) type in CMS */
-export type FolderContentType = Omit<
+export type FolderContentType = SkipCompositionBehaviors<
   BaseContentType & {
     baseType: '_folder';
     mayContainTypes?: Array<ContentType<AnyContentType> | '_self' | string>;
-  },
-  'compositionBehaviors'
+  }
 >;
 
 /** Represents the "Component" type (also called "Block") in CMS */
@@ -110,19 +110,17 @@ export type ComponentContentType = BaseContentType & {
 };
 
 /** This content type is used only internally */
-export type SectionContentType = Omit<
+export type SectionContentType = SkipCompositionBehaviors<
   BaseContentType & {
     baseType: '_section';
-  },
-  'compositionBehaviors'
+  }
 >;
 
 /** Represents a "Media" content type (Image, Media, Video) */
-export type MediaContentType = Omit<
+export type MediaContentType = SkipCompositionBehaviors<
   BaseContentType & {
     baseType: MediaStringTypes;
-  },
-  'compositionBehaviors'
+  }
 >;
 
 /** All possible content types */

--- a/packages/optimizely-cms-sdk/src/model/contentTypes.ts
+++ b/packages/optimizely-cms-sdk/src/model/contentTypes.ts
@@ -39,6 +39,7 @@ export type SuppliedContractValues<P extends PropertiesRecord = PropertiesRecord
   key: string;
   displayName: string;
   properties?: P;
+  baseType?: never;
 };
 
 type InnerContractValues = {
@@ -67,30 +68,39 @@ type MergedPropertiesType<T extends AnyContentType> = ('extends' extends keyof T
   ('properties' extends keyof T ? T['properties'] : {});
 
 /** Represents the Page type  in CMS */
-export type PageContentType = BaseContentType & {
-  baseType: '_page';
-  mayContainTypes?: Array<
-    | ContentType<PageContentType | ExperienceContentType | FolderContentType>
-    | '_self'
-    | string
-  >;
-};
+export type PageContentType = Omit<
+  BaseContentType & {
+    baseType: '_page';
+    mayContainTypes?: Array<
+      | ContentType<PageContentType | ExperienceContentType | FolderContentType>
+      | '_self'
+      | string
+    >;
+  },
+  'compositionBehaviors'
+>;
 
 /** Represents the Experience type  in CMS */
-export type ExperienceContentType = BaseContentType & {
-  baseType: '_experience';
-  mayContainTypes?: Array<
-    | ContentType<PageContentType | ExperienceContentType | FolderContentType>
-    | '_self'
-    | string
-  >;
-};
+export type ExperienceContentType = Omit<
+  BaseContentType & {
+    baseType: '_experience';
+    mayContainTypes?: Array<
+      | ContentType<PageContentType | ExperienceContentType | FolderContentType>
+      | '_self'
+      | string
+    >;
+  },
+  'compositionBehaviors'
+>;
 
 /** Represents the Folder (Used in the asset panel to organizing content and not in Graph) type in CMS */
-export type FolderContentType = BaseContentType & {
-  baseType: '_folder';
-  mayContainTypes?: Array<ContentType<AnyContentType> | '_self' | string>;
-};
+export type FolderContentType = Omit<
+  BaseContentType & {
+    baseType: '_folder';
+    mayContainTypes?: Array<ContentType<AnyContentType> | '_self' | string>;
+  },
+  'compositionBehaviors'
+>;
 
 /** Represents the "Component" type (also called "Block") in CMS */
 export type ComponentContentType = BaseContentType & {
@@ -100,14 +110,20 @@ export type ComponentContentType = BaseContentType & {
 };
 
 /** This content type is used only internally */
-export type SectionContentType = BaseContentType & {
-  baseType: '_section';
-};
+export type SectionContentType = Omit<
+  BaseContentType & {
+    baseType: '_section';
+  },
+  'compositionBehaviors'
+>;
 
 /** Represents a "Media" content type (Image, Media, Video) */
-export type MediaContentType = BaseContentType & {
-  baseType: MediaStringTypes;
-};
+export type MediaContentType = Omit<
+  BaseContentType & {
+    baseType: MediaStringTypes;
+  },
+  'compositionBehaviors'
+>;
 
 /** All possible content types */
 export type AnyContentType =

--- a/packages/optimizely-cms-sdk/src/model/properties.ts
+++ b/packages/optimizely-cms-sdk/src/model/properties.ts
@@ -70,30 +70,32 @@ export type FloatProperty = BaseProperty & {
   maximum?: number;
 } & WithEnum<number>;
 
+type BaseContentReferenceProperty = BaseProperty & {
+  type: 'contentReference';
+  contentType?: AnyContentType | string;
+};
+
 export type ContentReferenceProperty =
-  | (BaseProperty & {
-      type: 'contentReference';
-      contentType?: AnyContentType | string;
+  | (BaseContentReferenceProperty & {
       allowedTypes: PermittedTypes[];
       restrictedTypes?: PermittedTypes[];
     })
-  | (BaseProperty & {
-      type: 'contentReference';
-      contentType?: AnyContentType | string;
+  | (BaseContentReferenceProperty & {
       allowedTypes?: PermittedTypes[];
       restrictedTypes: PermittedTypes[];
     });
 
+type BaseContentProperty = BaseProperty & {
+  type: 'content';
+  contentType?: AnyContentType | string;
+};
+
 export type ContentProperty =
-  | (BaseProperty & {
-      type: 'content';
-      contentType?: AnyContentType | string;
+  | (BaseContentProperty & {
       allowedTypes: PermittedTypes[];
       restrictedTypes?: PermittedTypes[];
     })
-  | (BaseProperty & {
-      type: 'content';
-      contentType?: AnyContentType | string;
+  | (BaseContentProperty & {
       allowedTypes?: PermittedTypes[];
       restrictedTypes: PermittedTypes[];
     });

--- a/packages/optimizely-cms-sdk/src/model/properties.ts
+++ b/packages/optimizely-cms-sdk/src/model/properties.ts
@@ -26,25 +26,10 @@ type WithEnum<T> = {
 
 export type ArrayProperty<T extends ArrayItems> = BaseProperty & {
   type: 'array';
-  items: T;
+  items: Exclude<T, ArrayProperty<any>>;
   minItems?: number;
   maxItems?: number;
 };
-
-export type ArrayItems =
-  | StringProperty
-  | BooleanProperty
-  | BinaryProperty
-  | JsonProperty
-  | DateTimeProperty
-  | RichTextProperty
-  | UrlProperty
-  | IntegerProperty
-  | FloatProperty
-  | ContentReferenceProperty
-  | ContentProperty
-  | ComponentProperty<AnyContentType>
-  | LinkProperty;
 
 /** Represents the content type property "String" */
 export type StringProperty = BaseProperty & {
@@ -85,19 +70,48 @@ export type FloatProperty = BaseProperty & {
   maximum?: number;
 } & WithEnum<number>;
 
-export type ContentReferenceProperty = BaseProperty & {
-  type: 'contentReference';
-  contentType?: AnyContentType | string;
-  allowedTypes?: PermittedTypes[];
-  restrictedTypes?: PermittedTypes[];
-};
+export type ContentReferenceProperty =
+  | (BaseProperty & {
+      type: 'contentReference';
+      contentType?: AnyContentType | string;
+      allowedTypes: PermittedTypes[];
+      restrictedTypes?: PermittedTypes[];
+    })
+  | (BaseProperty & {
+      type: 'contentReference';
+      contentType?: AnyContentType | string;
+      allowedTypes?: PermittedTypes[];
+      restrictedTypes: PermittedTypes[];
+    });
 
-export type ContentProperty = BaseProperty & {
-  type: 'content';
-  contentType?: AnyContentType | string;
-  allowedTypes?: PermittedTypes[];
-  restrictedTypes?: PermittedTypes[];
-};
+export type ContentProperty =
+  | (BaseProperty & {
+      type: 'content';
+      contentType?: AnyContentType | string;
+      allowedTypes: PermittedTypes[];
+      restrictedTypes?: PermittedTypes[];
+    })
+  | (BaseProperty & {
+      type: 'content';
+      contentType?: AnyContentType | string;
+      allowedTypes?: PermittedTypes[];
+      restrictedTypes: PermittedTypes[];
+    });
+
+export type ArrayItems =
+  | StringProperty
+  | BooleanProperty
+  | BinaryProperty
+  | JsonProperty
+  | DateTimeProperty
+  | RichTextProperty
+  | UrlProperty
+  | IntegerProperty
+  | FloatProperty
+  | ContentReferenceProperty
+  | ContentProperty
+  | ComponentProperty<AnyContentType>
+  | LinkProperty;
 
 /**
  * Reprensents the content type property "Component".

--- a/packages/optimizely-cms-sdk/src/schema/__test__/toSchema.test.ts
+++ b/packages/optimizely-cms-sdk/src/schema/__test__/toSchema.test.ts
@@ -154,7 +154,7 @@ describe('toSchema', () => {
         key: 'RefTest',
         baseType: '_component',
         displayName: 'Ref Test',
-        properties: { image: { type: 'contentReference' } },
+        properties: { image: { type: 'contentReference', allowedTypes: ['*'] } },
       });
       const schema = toSchema(ct);
       const result = schema.safeParse({
@@ -173,7 +173,7 @@ describe('toSchema', () => {
         key: 'ContentTest',
         baseType: '_component',
         displayName: 'Content Test',
-        properties: { area: { type: 'content' } },
+        properties: { area: { type: 'content', allowedTypes: ['*'] } },
       });
       const schema = toSchema(ct);
       const result = schema.safeParse({

--- a/packages/optimizely-cms-sdk/src/schema/toSchema.ts
+++ b/packages/optimizely-cms-sdk/src/schema/toSchema.ts
@@ -323,8 +323,8 @@ function validateProperty(value: unknown, property: AnyProperty, path: string[],
       const resolved = typeof property.contentType === 'string'
         ? getContentType(property.contentType)
         : property.contentType;
-      if (resolved && 'baseType' in resolved) {
-        validateComponent(value, resolved, path, errors, new Set(visited));
+      if (resolved && 'baseType' in resolved && resolved.baseType) {
+        validateComponent(value, resolved as AnyContentType, path, errors, new Set(visited));
       }
       break;
     }
@@ -420,6 +420,7 @@ export function toSchema<T extends AnyContentType>(
   options?: SchemaOptions,
 ) {
   const strict = options?.strict ?? false;
+  const baseType = (ct as AnyContentType).baseType;
 
   return new Schema<ContentProps<T>>((data: unknown) => {
     const errors: ValidationError[] = [];
@@ -441,14 +442,14 @@ export function toSchema<T extends AnyContentType>(
       }
     }
 
-    if (ct.baseType === '_experience') {
+    if (baseType === '_experience') {
       knownKeys.add('composition');
       if (obj.composition !== null && obj.composition !== undefined) {
         validateExperienceNode(obj.composition, ['composition'], errors);
       }
     }
 
-    if (ct.baseType === '_section') {
+    if (baseType === '_section') {
       knownKeys.add('key');
       knownKeys.add('nodes');
       if (typeof obj.key !== 'string') {


### PR DESCRIPTION
 Explicit rules added through type system:

 - Contracts cannot have `baseType`
 - `compositionBehaviors` only on `_component`
 - `mayContainTypes` only on `_page`, `_experience`, `_folder`
 - Component property requires `contentType`
 - `content` and `contentReference` require `allowedTypes` or `restrictedTypes`
