### PR TITLE
SDK returns 404 when graphUrl is set from OPTIMIZELY_GRAPH_GATEWAY environment variable

### DIFF
--- a/.changeset/solid-books-start.md
+++ b/.changeset/solid-books-start.md
@@ -1,0 +1,6 @@
+---
+'@optimizely/cms-sdk': patch
+---
+
+Normalize graphUrl to auto-append /content/v2 when missing, fixing 404 errors when using
+OPTIMIZELY_GRAPH_GATEWAY environment variable

--- a/docs/5-fetching.md
+++ b/docs/5-fetching.md
@@ -94,7 +94,7 @@ config({
 #### config() Parameters
 
 - **`apiKey`** (required): Your Optimizely Graph API key (Single key from CMS Settings → API Keys)
-- **`graphUrl`** (optional): Custom Graph URL. Defaults to `https://cg.optimizely.com/content/v2`
+- **`graphUrl`** (optional): Custom Graph URL. Defaults to `https://cg.optimizely.com/content/v2`. If the URL does not include `/content/v2`, the SDK appends it automatically
 - **`host`** (optional): Default application host for path filtering. Useful for multi-site scenarios
 - **`maxFragmentThreshold`** (optional): Maximum number of GraphQL fragments before logging warnings. Defaults to `100`
 - **`cache`** (optional): Enable/disable server-side caching for all queries. Defaults to `true`

--- a/packages/optimizely-cms-sdk/src/graph/__test__/getClient.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/getClient.test.ts
@@ -148,6 +148,42 @@ describe('getClient - Critical Edge Cases', () => {
     });
   });
 
+  describe('CRITICAL: graphUrl normalization (issue #468)', () => {
+    test('should append /content/v2 when graphUrl is just the gateway base URL', () => {
+      config({ apiKey: 'test-key', graphUrl: 'https://cg.optimizely.com' });
+      const client = getClient();
+
+      expect(client.graphUrl).toBe('https://cg.optimizely.com/content/v2');
+    });
+
+    test('should append /content/v2 when graphUrl has trailing slash', () => {
+      config({ apiKey: 'test-key', graphUrl: 'https://cg.optimizely.com/' });
+      const client = getClient();
+
+      expect(client.graphUrl).toBe('https://cg.optimizely.com/content/v2');
+    });
+
+    test('should not double-append when graphUrl already has /content/v2', () => {
+      config({ apiKey: 'test-key', graphUrl: 'https://cg.optimizely.com/content/v2' });
+      const client = getClient();
+
+      expect(client.graphUrl).toBe('https://cg.optimizely.com/content/v2');
+    });
+
+    test('should work with staging gateway URL', () => {
+      config({ apiKey: 'test-key', graphUrl: 'https://cg.staging.optimizely.com' });
+      const client = getClient();
+
+      expect(client.graphUrl).toBe('https://cg.staging.optimizely.com/content/v2');
+    });
+
+    test('should normalize via GraphClient constructor directly', () => {
+      const client = new GraphClient('test-key', { graphUrl: 'https://cg.optimizely.com' });
+
+      expect(client.graphUrl).toBe('https://cg.optimizely.com/content/v2');
+    });
+  });
+
   describe('Default values', () => {
     test('should use all defaults when only key is provided', () => {
       config({ apiKey: 'minimal-key' });

--- a/packages/optimizely-cms-sdk/src/graph/constants.ts
+++ b/packages/optimizely-cms-sdk/src/graph/constants.ts
@@ -5,6 +5,8 @@ import { SDK_VERSION } from '../generated/version.js';
  */
 export const DEFAULT_GRAPH_URL = 'https://cg.optimizely.com/content/v2';
 
+export const GRAPH_PATH = '/content/v2';
+
 /**
  * Default User-Agent string for HTTP requests to Graph API.
  */

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_USER_AGENT,
   DEFAULT_MAX_FRAGMENT_THRESHOLD,
   DEFAULT_EXPAND_CONTRACTS,
+  GRAPH_PATH,
 } from './constants.js';
 
 /** Configuration for initializing the Optimizely Graph Client */
@@ -322,6 +323,14 @@ function decorateWithContext(obj: any, params: PreviewParams): any {
   return obj;
 }
 
+function normalizeGraphUrl(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.pathname === '/' || parsed.pathname === '') {
+    parsed.pathname = GRAPH_PATH;
+  }
+  return parsed.origin + parsed.pathname.replace(/\/+$/, '');
+}
+
 export class GraphClient {
   apiKey: string;
   graphUrl: string;
@@ -335,7 +344,7 @@ export class GraphClient {
   // The key is required, other options have defaults or can be set globally
   constructor(apiKey: string, options: Omit<GraphOptions, 'apiKey'> = {}) {
     this.apiKey = apiKey;
-    this.graphUrl = options.graphUrl || DEFAULT_GRAPH_URL;
+    this.graphUrl = normalizeGraphUrl(options.graphUrl || DEFAULT_GRAPH_URL);
     this.maxFragmentThreshold =
       options.maxFragmentThreshold ?? DEFAULT_MAX_FRAGMENT_THRESHOLD;
     this.expandContracts = options.expandContracts ?? DEFAULT_EXPAND_CONTRACTS;


### PR DESCRIPTION
**Problem**
The OPTIMIZELY_GRAPH_GATEWAY environment variable provided by the Optimizely hosted environment contains only the base URL (https://cg.optimizely.com), without the required /content/v2 path. When users follow the documentation and pass this value directly to graphUrl, the SDK sends requests to the wrong endpoint, resulting in a 404 Not Found error.

**Root Cause**
The GraphClient constructor used graphUrl as-is without validating or normalizing the path. There was a mismatch between:
The SDK default: https://cg.optimizely.com/content/v2 (full path)
The hosted env var OPTIMIZELY_GRAPH_GATEWAY: https://cg.optimizely.com (base only)
**Solution**
Auto-append /content/v2 to graphUrl when the path is missing. This is backward-compatible — URLs that already include /content/v2 are unchanged.

**Changes**
packages/optimizely-cms-sdk/src/graph/constants.ts — Added GRAPH_PATH constant
packages/optimizely-cms-sdk/src/graph/index.ts — Added normalizeGraphUrl() function, applied in GraphClient constructor
packages/optimizely-cms-sdk/src/graph/__test__/getClient.test.ts — Added 5 test cases covering normalization (base URL, trailing slash, idempotency, staging URL, direct constructor)
docs/5-fetching.md — Added note that the SDK auto-appends /content/v2 if missing
Bug: CMS-54607