### PR TITLE
CMS-54844 Refactor section properties access to be flat on `content` and update tests

### DIFF
--- a/.changeset/olive-donuts-shave.md
+++ b/.changeset/olive-donuts-shave.md
@@ -1,0 +1,8 @@
+---
+'@optimizely/cms-sdk': patch
+---
+
+Access section properties directly on `content`
+
+Custom properties of `_section` content types are now available flat on `content`, the same as
+every other content type, instead of nested under `content.component`.

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ graphify-out/
 *-workspace/
 
 config.bat
+test-app
+*.tsbuildinfo

--- a/packages/optimizely-cms-sdk/src/infer.ts
+++ b/packages/optimizely-cms-sdk/src/infer.ts
@@ -141,15 +141,10 @@ type InferProps<T extends AnyContentType> =
     {
       properties: Record<string, AnyProperty>;
     }
-  ) ? T extends SectionContentType
-      ? {
-        component: {
-          [Key in EnabledKeys<T['properties']>]: InferFromProperty<T['properties'][Key]> | null
-        };
-      } :
-      {
-        [Key in EnabledKeys<T['properties']>]: InferFromProperty<T['properties'][Key]> | null;
-      }
+  ) ?
+    {
+      [Key in EnabledKeys<T['properties']>]: InferFromProperty<T['properties'][Key]> | null;
+    }
   : {};
 
 // Special fields for Experience
@@ -179,6 +174,9 @@ export type ExperienceStructureNode = ExperienceCompositionNode & {
   /** "row", "column", etc. */
   nodeType: string;
   nodes?: ExperienceNode[];
+
+  /** User-defined properties of a section. `null` for rows, columns, etc. */
+  component?: Record<string, unknown> | null;
 };
 export type ExperienceComponentNode = ExperienceCompositionNode & {
   nodeType: 'component';

--- a/packages/optimizely-cms-sdk/src/react/__test__/sectionProperties.test.tsx
+++ b/packages/optimizely-cms-sdk/src/react/__test__/sectionProperties.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { initReactComponentRegistry, OptimizelyComposition } from '../server.js';
+import { ExperienceNode } from '../../infer.js';
+
+function HeroSection({ content }: { content: any }) {
+  return (
+    <div data-testid="section">
+      {content.heading}|{content.key}|{content.nodes?.length ?? 0}
+    </div>
+  );
+}
+
+beforeEach(() => {
+  initReactComponentRegistry({ resolver: { HeroSection } });
+});
+
+describe('Section nodes', () => {
+  it('exposes the section properties directly on `content`', async () => {
+    const node: ExperienceNode = {
+      __typename: 'CompositionStructureNode',
+      key: 'section-1',
+      type: 'HeroSection',
+      nodeType: 'section',
+      layoutType: null,
+      displayName: 'Hero',
+      displayTemplateKey: null,
+      displaySettings: null,
+      component: { __typename: 'HeroSection', heading: 'Welcome' },
+      nodes: [],
+    };
+
+    // `OptimizelyComponent` is an async server component, so resolve it before rendering
+    const [element] = OptimizelyComposition({ nodes: [node] }) as any[];
+    const { getByTestId } = render(await element.type(element.props));
+
+    // properties are flat (`content.heading`), node fields are preserved
+    expect(getByTestId('section')).toHaveTextContent('Welcome|section-1|0');
+  });
+});

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -322,13 +322,14 @@ export function OptimizelyComposition({
       return <div>???</div>;
     }
 
+    // Merge user-defined properties from `_section` nodes
+    const componentData = 'component' in node ? (node.component as object) : {};
+
     return (
       <OptimizelyComponent
         key={node.key}
         content={{
-          // `node.component` contains the section's user-defined properties. Spread first so
-          // node fields (`key`, `nodes`, ...) win, and properties are accessible flat.
-          ...node.component,
+          ...componentData,
           ...node,
           __typename: type,
           __tag: tag,

--- a/packages/optimizely-cms-sdk/src/react/server.tsx
+++ b/packages/optimizely-cms-sdk/src/react/server.tsx
@@ -326,6 +326,9 @@ export function OptimizelyComposition({
       <OptimizelyComponent
         key={node.key}
         content={{
+          // `node.component` contains the section's user-defined properties. Spread first so
+          // node fields (`key`, `nodes`, ...) win, and properties are accessible flat.
+          ...node.component,
           ...node,
           __typename: type,
           __tag: tag,


### PR DESCRIPTION
- Update `InferProps` and `<OptimizelyComponent/>` to handle `component` property introduced by `_section` contentType