### PR TITLE
CMS-54832 Add strict validation and typescript type restrictions for content and contentReference properties

### DIFF
--- a/.changeset/breezy-signs-cut.md
+++ b/.changeset/breezy-signs-cut.md
@@ -4,3 +4,13 @@
 ---
 
 Add validations and type restrictions for properties with content and contentReference
+
+`opti-cms config push` now stops before uploading when a `content` or `contentReference` property (or array item) is misconfigured:
+
+- Missing constraints — declare `contentType`, or `allowedTypes`/`restrictedTypes`.
+- Empty `allowedTypes`/`restrictedTypes` — list at least one content type, or remove the field.
+- `contentType` combined with `allowedTypes`/`restrictedTypes` — declare only one of them.
+
+Previously unconstrained properties were only a warning; they make the SDK generate nested GraphQL fragments for every content type.
+
+**Migrating:** give every existing `content` and `contentReference` property a `contentType` or a non-empty `allowedTypes`/`restrictedTypes` before upgrading. Narrower constraints mean smaller queries and faster responses. See [Content Relationships](https://github.com/episerver/content-js-sdk/blob/main/docs/3-modelling.md#migrating-existing-content-types) for examples.

--- a/.changeset/breezy-signs-cut.md
+++ b/.changeset/breezy-signs-cut.md
@@ -1,0 +1,6 @@
+---
+'@optimizely/cms-cli': major
+'@optimizely/cms-sdk': major
+---
+
+Add validations and type restrictions for properties with content and contentReference

--- a/docs/3-modelling.md
+++ b/docs/3-modelling.md
@@ -181,7 +181,7 @@ Array properties support:
 - All item types except `array` (no nested arrays)
 
 > [!IMPORTANT]
-> When using `type: 'content'` or `type: 'contentReference'` within array items, always specify `allowedTypes` or `restrictedTypes`. Without these constraints, the SDK will generate nested GraphQL fragments for all possible content types, causing severe performance issues and very slow queries.
+> When using `type: 'content'` or `type: 'contentReference'` within array items, always specify `allowedTypes` or `restrictedTypes`. Without these constraints, the SDK will generate nested GraphQL fragments for all possible content types, causing severe performance issues and very slow queries. See [Content Relationships](#content-relationships) — `opti-cms config push` rejects unconstrained array items.
 >
 > [!TIP]
 > You can use contracts in `allowedTypes` to allow all content types that extend a specific contract. See the [Content Relationships](#content-relationships) section for examples.
@@ -302,7 +302,27 @@ const BlogPageContentType = contentType({
 **`restrictedTypes`** - Blacklist of content types that cannot be selected. Uses the same format as `allowedTypes`.
 
 > [!IMPORTANT]
-> Always specify either `allowedTypes` or `restrictedTypes` for `content` and `contentReference` properties. Without these constraints, the SDK will generate nested GraphQL fragments for all possible content types, causing severe performance issues and very slow queries.
+> Every `content` and `contentReference` property must declare exactly one form of constraint: either a single `contentType`, or a non-empty `allowedTypes`/`restrictedTypes`. Never both, and never an empty list. `opti-cms config push` fails before uploading anything when a property breaks this. Unconstrained properties make the SDK generate nested GraphQL fragments for all possible content types, causing severe performance issues and very slow queries.
+
+#### Migrating existing content types
+
+Content types written before this rule was enforced may have `content` or `contentReference` properties with no constraints, or with an empty `allowedTypes`/`restrictedTypes`. `opti-cms config push` now reports each one and exits without uploading. Add the constraint that matches your intent:
+
+```ts
+// Before - unconstrained, queries every content type
+properties: {
+  featuredArticle: { type: 'content' },
+  hero: { type: 'contentReference', allowedTypes: [] },
+}
+
+// After - pick one form of constraint per property
+properties: {
+  featuredArticle: { type: 'contentReference', allowedTypes: [ArticleContentType] },
+  hero: { type: 'content', contentType: HeroContentType },
+}
+```
+
+If a property really should accept a wide range, use `restrictedTypes` to exclude what it cannot hold (for example `restrictedTypes: [SomeContentType]`) instead of leaving it open. Run `opti-cms config push --dryRun` to list every remaining violation before pushing.
 
 ## Container Types with mayContainTypes
 

--- a/packages/optimizely-cms-cli/src/commands/config/push.ts
+++ b/packages/optimizely-cms-cli/src/commands/config/push.ts
@@ -16,7 +16,10 @@ import { mapContentToManifest } from '../../mapper/contentToPackage.js';
 import { pathToFileURL } from 'node:url';
 import { constants } from 'node:fs';
 import { translateErrorMessage } from '../../utils/errors.js';
-import { contractToManifest, validateContentAreaConstraints } from '../../utils/mapping.js';
+import {
+  contractToManifest,
+  validateContentAreaConstraints,
+} from '../../utils/mapping.js';
 import { syncLocales } from '../../service/localeService.js';
 
 export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
@@ -80,17 +83,22 @@ export default class ConfigPush extends BaseCommand<typeof ConfigPush> {
     );
 
     // Validate content area constraints
-    const { warnings: constraintWarnings } = validateContentAreaConstraints(contentTypes);
-    if (constraintWarnings.length > 0) {
-      console.warn(chalk.yellow('\nContent Area Warnings:'));
-      for (const warning of constraintWarnings) {
-        console.warn(chalk.yellow(`  ⚠ ${warning}`));
-      }
-      console.warn(
-        chalk.dim(
-          '  Tip: Add "allowedTypes" or "restrictedTypes" to avoid excessive fragment generation at runtime.\n',
+    const { errors: constraintErrors } = validateContentAreaConstraints(contentTypes);
+    if (constraintErrors.length > 0) {
+      console.error(
+        chalk.red(
+          `\nInvalid content type configuration (${constraintErrors.length} ${constraintErrors.length === 1 ? 'issue' : 'issues'} found):`,
         ),
       );
+      for (const error of constraintErrors) {
+        console.error(chalk.red(`  ✖ ${error}`));
+      }
+      console.error(
+        chalk.dim(
+          '\n  Resolve the issues above and run the command again. Nothing was pushed to the CMS.\n',
+        ),
+      );
+      process.exit(1);
     }
 
     // Validate and normalize property groups

--- a/packages/optimizely-cms-cli/src/tests/validateContentAreaConstraints.test.ts
+++ b/packages/optimizely-cms-cli/src/tests/validateContentAreaConstraints.test.ts
@@ -3,7 +3,26 @@ import { validateContentAreaConstraints } from '../utils/mapping.js';
 import { contentType } from '@optimizely/cms-sdk';
 
 describe('validateContentAreaConstraints', () => {
-  it('should return warnings for content properties without allowedTypes or restrictedTypes', () => {
+  it('should return errors for content properties without any type constraints', () => {
+    const types = [
+      contentType({
+        key: 'PageType',
+        baseType: '_page',
+        displayName: 'Page',
+        properties: {
+          mainContent: { type: 'content' } as any,
+        },
+      }),
+    ];
+
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('PageType');
+    expect(errors[0]).toContain('mainContent');
+    expect(errors[0]).toContain('missing type constraints');
+  });
+
+  it('should return errors for empty allowedTypes or restrictedTypes', () => {
     const types = [
       contentType({
         key: 'PageType',
@@ -14,17 +33,45 @@ describe('validateContentAreaConstraints', () => {
             type: 'content',
             restrictedTypes: [],
           },
+          image: {
+            type: 'contentReference',
+            allowedTypes: [],
+            restrictedTypes: [],
+          },
         },
       }),
     ];
 
-    const { warnings } = validateContentAreaConstraints(types);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('PageType');
-    expect(warnings[0]).toContain('mainContent');
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain('mainContent');
+    expect(errors[0]).toContain('empty type constraints');
+    expect(errors[0]).toContain('"restrictedTypes"');
+    expect(errors[1]).toContain('"allowedTypes" and "restrictedTypes"');
   });
 
-  it('should return no warnings when allowedTypes is set', () => {
+  it('should return an error for an empty list even when contentType is set', () => {
+    const types = [
+      contentType({
+        key: 'PageType',
+        baseType: '_page',
+        displayName: 'Page',
+        properties: {
+          image: {
+            type: 'contentReference',
+            contentType: 'ImageType',
+            allowedTypes: [],
+          } as any,
+        },
+      }),
+    ];
+
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('empty type constraints');
+  });
+
+  it('should return no errors when allowedTypes is set', () => {
     const types = [
       contentType({
         key: 'PageType',
@@ -39,11 +86,11 @@ describe('validateContentAreaConstraints', () => {
       }),
     ];
 
-    const { warnings } = validateContentAreaConstraints(types);
-    expect(warnings).toHaveLength(0);
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(0);
   });
 
-  it('should return no warnings when restrictedTypes is set', () => {
+  it('should return no errors when restrictedTypes is set', () => {
     const types = [
       contentType({
         key: 'PageType',
@@ -58,8 +105,8 @@ describe('validateContentAreaConstraints', () => {
       }),
     ];
 
-    const { warnings } = validateContentAreaConstraints(types);
-    expect(warnings).toHaveLength(0);
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(0);
   });
 
   it('should detect unconstrained array items of type content', () => {
@@ -71,21 +118,19 @@ describe('validateContentAreaConstraints', () => {
         properties: {
           sections: {
             type: 'array',
-            items: {
-              type: 'content',
-              restrictedTypes: [],
-            },
-          },
+            items: { type: 'content' },
+          } as any,
         },
       }),
     ];
 
-    const { warnings } = validateContentAreaConstraints(types);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('sections');
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('sections');
+    expect(errors[0]).toContain('missing type constraints');
   });
 
-  it('should return no warnings for content types without properties', () => {
+  it('should return no errors for content types without properties', () => {
     const types = [
       contentType({
         key: 'EmptyType',
@@ -95,13 +140,13 @@ describe('validateContentAreaConstraints', () => {
       }),
     ];
 
-    const { warnings } = validateContentAreaConstraints(types);
-    expect(warnings).toHaveLength(0);
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(0);
   });
 
-  it('should return no warnings for empty content types array', () => {
-    const { warnings } = validateContentAreaConstraints([]);
-    expect(warnings).toHaveLength(0);
+  it('should return no errors for empty content types array', () => {
+    const { errors } = validateContentAreaConstraints([]);
+    expect(errors).toHaveLength(0);
   });
 
   it('should detect multiple violations across multiple content types', () => {
@@ -111,10 +156,7 @@ describe('validateContentAreaConstraints', () => {
         baseType: '_page',
         displayName: 'Page A',
         properties: {
-          area1: {
-            type: 'content',
-            restrictedTypes: [],
-          },
+          area1: { type: 'content' } as any,
         },
       }),
       contentType({
@@ -122,21 +164,18 @@ describe('validateContentAreaConstraints', () => {
         baseType: '_page',
         displayName: 'Page B',
         properties: {
-          area2: {
-            type: 'content',
-            restrictedTypes: [],
-          },
+          area2: { type: 'content', restrictedTypes: [] },
         },
       }),
     ];
 
-    const { warnings } = validateContentAreaConstraints(types);
-    expect(warnings).toHaveLength(2);
-    expect(warnings[0]).toContain('PageA');
-    expect(warnings[1]).toContain('PageB');
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain('PageA');
+    expect(errors[1]).toContain('PageB');
   });
 
-  it('should not warn for non-content property types', () => {
+  it('should not report non-content property types', () => {
     const types = [
       contentType({
         key: 'PageType',
@@ -150,7 +189,95 @@ describe('validateContentAreaConstraints', () => {
       }),
     ];
 
-    const { warnings } = validateContentAreaConstraints(types);
-    expect(warnings).toHaveLength(0);
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should error for an unconstrained contentReference', () => {
+    const types = [
+      contentType({
+        key: 'PageType',
+        baseType: '_page',
+        displayName: 'Page',
+        properties: {
+          image: { type: 'contentReference' } as any,
+        },
+      }),
+    ];
+
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('image');
+    expect(errors[0]).toContain('missing type constraints');
+  });
+
+  it('should return no errors when only contentType is set', () => {
+    const types = [
+      contentType({
+        key: 'PageType',
+        baseType: '_page',
+        displayName: 'Page',
+        properties: {
+          image: { type: 'contentReference', contentType: 'ImageType' } as any,
+          area: { type: 'content', contentType: 'Banner' } as any,
+        },
+      }),
+    ];
+
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should error when contentType is combined with allowedTypes or restrictedTypes', () => {
+    const types = [
+      contentType({
+        key: 'PageType',
+        baseType: '_page',
+        displayName: 'Page',
+        properties: {
+          image: {
+            type: 'contentReference',
+            contentType: 'ImageType',
+            allowedTypes: ['_image'],
+          } as any,
+          area: {
+            type: 'content',
+            contentType: 'Banner',
+            restrictedTypes: ['Hero'],
+          } as any,
+        },
+      }),
+    ];
+
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain('image');
+    expect(errors[0]).toContain('conflicting type constraints');
+    expect(errors[1]).toContain('area');
+  });
+
+  it('should error for array items combining contentType with allowedTypes', () => {
+    const types = [
+      contentType({
+        key: 'PageType',
+        baseType: '_page',
+        displayName: 'Page',
+        properties: {
+          sections: {
+            type: 'array',
+            items: {
+              type: 'content',
+              contentType: 'Banner',
+              allowedTypes: ['Hero'],
+            },
+          } as any,
+        },
+      }),
+    ];
+
+    const { errors } = validateContentAreaConstraints(types);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('sections');
+    expect(errors[0]).toContain('conflicting type constraints');
   });
 });

--- a/packages/optimizely-cms-cli/src/utils/mapping.ts
+++ b/packages/optimizely-cms-cli/src/utils/mapping.ts
@@ -157,33 +157,52 @@ const mapAllowedRestrictedTypes = (updatedValue: any, parentKey: string): any =>
 };
 
 /**
- * Validates that content area properties have `allowedTypes` or `restrictedTypes` defined.
- * Returns warnings for properties that could cause excessive fragment generation at runtime.
+ * Validates `content` and `contentReference` properties (including array items).
+ *
+ * Every such property must declare exactly one form of type constraint: either
+ * `contentType`, or a non-empty `allowedTypes`/`restrictedTypes`. Declaring both is a
+ * conflict, declaring neither leaves the property unbounded and causes excessive GraphQL
+ * fragment generation at runtime.
  */
 export const validateContentAreaConstraints = (
   contentTypes: ContentTypes.AnyContentType[],
-): { warnings: string[] } => {
-  const warnings: string[] = [];
+): { errors: string[] } => {
+  const errors: string[] = [];
 
   for (const ct of contentTypes) {
     if (!ct.properties) continue;
 
     for (const [propName, prop] of Object.entries(ct.properties)) {
-      const isUnconstrainedContent =
-        (prop.type === 'content' && !hasTypeConstraints(prop)) ||
-        (prop.type === 'array' && 'items' in prop && (prop as any).items?.type === 'content' && !hasTypeConstraints((prop as any).items));
+      // an array delegates its constraints to `items`
+      const target: any = prop.type === 'array' ? (prop as any).items : prop;
+      if (!target || !['content', 'contentReference'].includes(target.type)) continue;
 
-      if (isUnconstrainedContent) {
-        warnings.push(
-          `Content type "${ct.key}", property "${propName}": ` +
-            `content area has no "allowedTypes" or "restrictedTypes". ` +
-            `This may cause excessive GraphQL fragment generation at runtime.`,
+      const location = `Content type "${ct.key}", property "${propName}" (${target.type})`;
+      const hasConstraints = hasTypeConstraints(target);
+      const emptyLists = ['allowedTypes', 'restrictedTypes'].filter(
+        name => Array.isArray(target[name]) && target[name].length === 0,
+      );
+
+      if (emptyLists.length > 0) {
+        errors.push(
+          `${location}: empty type constraints. ` +
+            `${emptyLists.map(name => `"${name}"`).join(' and ')} must list at least one content type, or be removed.`,
+        );
+      } else if (target.contentType && hasConstraints) {
+        errors.push(
+          `${location}: conflicting type constraints. ` +
+            `"contentType" cannot be combined with "allowedTypes" or "restrictedTypes", declare only one of them.`,
+        );
+      } else if (!target.contentType && !hasConstraints) {
+        errors.push(
+          `${location}: missing type constraints. ` +
+            `Declare "contentType", or "allowedTypes"/"restrictedTypes", to define which content types are permitted.`,
         );
       }
     }
   }
 
-  return { warnings };
+  return { errors };
 };
 
 const hasTypeConstraints = (prop: any): boolean =>

--- a/packages/optimizely-cms-sdk/src/model/__test__/restrictions.test-d.ts
+++ b/packages/optimizely-cms-sdk/src/model/__test__/restrictions.test-d.ts
@@ -75,7 +75,7 @@ test('content/contentReference require allowedTypes or restrictedTypes', () => {
     displayName: 'Page',
     baseType: '_page',
     properties: {
-      // @ts-expect-error - contentReference requires either allowedTypes or restrictedTypes
+      //@ts-expect-error - contentReference requires either allowedTypes or restrictedTypes
       ref: { type: 'contentReference' },
     },
   });
@@ -116,7 +116,11 @@ test('content/contentReference require allowedTypes or restrictedTypes', () => {
     displayName: 'Page',
     baseType: '_page',
     properties: {
-      ref: { type: 'contentReference', allowedTypes: ['_component'], restrictedTypes: ['other'] },
+      ref: {
+        type: 'contentReference',
+        allowedTypes: ['_component'],
+        restrictedTypes: ['other'],
+      },
     },
   });
 });

--- a/packages/optimizely-cms-sdk/src/model/__test__/restrictions.test-d.ts
+++ b/packages/optimizely-cms-sdk/src/model/__test__/restrictions.test-d.ts
@@ -75,7 +75,7 @@ test('content/contentReference require allowedTypes or restrictedTypes', () => {
     displayName: 'Page',
     baseType: '_page',
     properties: {
-      //@ts-expect-error - contentReference requires either allowedTypes or restrictedTypes
+      // @ts-expect-error - contentReference requires either allowedTypes or restrictedTypes
       ref: { type: 'contentReference' },
     },
   });

--- a/packages/optimizely-cms-sdk/src/model/properties.ts
+++ b/packages/optimizely-cms-sdk/src/model/properties.ts
@@ -74,7 +74,7 @@ export type FloatProperty = BaseProperty & {
   maximum?: number;
 } & WithEnum<number>;
 
-/** Represents the content type property "ContentReference" */
+/** Represents type constraints for "content" and "contentReference" properties */
 type ContentAndRefBlock =
   | {
       contentType: AnyContentType | string;

--- a/packages/optimizely-cms-sdk/src/model/properties.ts
+++ b/packages/optimizely-cms-sdk/src/model/properties.ts
@@ -74,35 +74,35 @@ export type FloatProperty = BaseProperty & {
   maximum?: number;
 } & WithEnum<number>;
 
-type BaseContentReferenceProperty = BaseProperty & {
-  type: 'contentReference';
-  contentType?: AnyContentType | string;
-};
-
-export type ContentReferenceProperty =
-  | (BaseContentReferenceProperty & {
+/** Represents the content type property "ContentReference" */
+type ContentAndRefBlock =
+  | {
+      contentType: AnyContentType | string;
+      allowedTypes?: never;
+      restrictedTypes?: never;
+    }
+  | {
+      contentType?: never;
       allowedTypes: PermittedTypes[];
       restrictedTypes?: PermittedTypes[];
-    })
-  | (BaseContentReferenceProperty & {
+    }
+  | {
+      contentType?: never;
       allowedTypes?: PermittedTypes[];
       restrictedTypes: PermittedTypes[];
-    });
+    };
+
+type BaseContentReferenceProperty = BaseProperty & {
+  type: 'contentReference';
+};
 
 type BaseContentProperty = BaseProperty & {
   type: 'content';
-  contentType?: AnyContentType | string;
 };
 
-export type ContentProperty =
-  | (BaseContentProperty & {
-      allowedTypes: PermittedTypes[];
-      restrictedTypes?: PermittedTypes[];
-    })
-  | (BaseContentProperty & {
-      allowedTypes?: PermittedTypes[];
-      restrictedTypes: PermittedTypes[];
-    });
+export type ContentReferenceProperty = BaseContentReferenceProperty & ContentAndRefBlock;
+
+export type ContentProperty = BaseContentProperty & ContentAndRefBlock;
 
 export type ArrayItems =
   | StringProperty

--- a/packages/optimizely-cms-sdk/src/schema/toSchema.ts
+++ b/packages/optimizely-cms-sdk/src/schema/toSchema.ts
@@ -320,9 +320,9 @@ function validateProperty(value: unknown, property: AnyProperty, path: string[],
       validateContent(value, path, errors);
       break;
     case 'component': {
-      const resolved = typeof property.contentType === 'string'
-        ? getContentType(property.contentType)
-        : property.contentType;
+      // ponytail: typed as AnyContentType, but a content type key string can arrive at runtime
+      const ct: AnyContentType | string = property.contentType;
+      const resolved = typeof ct === 'string' ? getContentType(ct) : ct;
       if (resolved && 'baseType' in resolved && resolved.baseType) {
         validateComponent(value, resolved as AnyContentType, path, errors, new Set(visited));
       }

--- a/packages/optimizely-cms-sdk/src/schema/toSchema.ts
+++ b/packages/optimizely-cms-sdk/src/schema/toSchema.ts
@@ -45,7 +45,9 @@ export type ParseResult<T> = ParseSuccess<T> | ParseFailure;
  */
 export class SchemaValidationError extends Error {
   constructor(public readonly errors: ValidationError[]) {
-    super(`Validation failed with ${errors.length} error(s):\n${errors.map(e => `  [${e.path.join('.')}] ${e.message}`).join('\n')}`);
+    super(
+      `Validation failed with ${errors.length} error(s):\n${errors.map(e => `  [${e.path.join('.')}] ${e.message}`).join('\n')}`,
+    );
     this.name = 'SchemaValidationError';
   }
 }
@@ -107,8 +109,19 @@ export class Schema<T = unknown> {
   }
 }
 
-function addError(errors: ValidationError[], path: string[], message: string, expected?: string, received?: string) {
-  errors.push({ path, message, ...(expected !== undefined && { expected }), ...(received !== undefined && { received }) });
+function addError(
+  errors: ValidationError[],
+  path: string[],
+  message: string,
+  expected?: string,
+  received?: string,
+) {
+  errors.push({
+    path,
+    message,
+    ...(expected !== undefined && { expected }),
+    ...(received !== undefined && { received }),
+  });
 }
 
 function typeOf(value: unknown): string {
@@ -117,9 +130,20 @@ function typeOf(value: unknown): string {
   return typeof value;
 }
 
-function validateString(value: unknown, property: StringProperty, path: string[], errors: ValidationError[]) {
+function validateString(
+  value: unknown,
+  property: StringProperty,
+  path: string[],
+  errors: ValidationError[],
+) {
   if (typeof value !== 'string') {
-    addError(errors, path, `Expected string, received ${typeOf(value)}`, 'string', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected string, received ${typeOf(value)}`,
+      'string',
+      typeOf(value),
+    );
     return;
   }
 
@@ -145,9 +169,20 @@ function validateString(value: unknown, property: StringProperty, path: string[]
   }
 }
 
-function validateInteger(value: unknown, property: IntegerProperty, path: string[], errors: ValidationError[]) {
+function validateInteger(
+  value: unknown,
+  property: IntegerProperty,
+  path: string[],
+  errors: ValidationError[],
+) {
   if (typeof value !== 'number') {
-    addError(errors, path, `Expected integer, received ${typeOf(value)}`, 'integer', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected integer, received ${typeOf(value)}`,
+      'integer',
+      typeOf(value),
+    );
     return;
   }
   if (!Number.isInteger(value)) {
@@ -171,9 +206,20 @@ function validateInteger(value: unknown, property: IntegerProperty, path: string
   }
 }
 
-function validateFloat(value: unknown, property: FloatProperty, path: string[], errors: ValidationError[]) {
+function validateFloat(
+  value: unknown,
+  property: FloatProperty,
+  path: string[],
+  errors: ValidationError[],
+) {
   if (typeof value !== 'number') {
-    addError(errors, path, `Expected number, received ${typeOf(value)}`, 'number', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected number, received ${typeOf(value)}`,
+      'number',
+      typeOf(value),
+    );
     return;
   }
 
@@ -195,58 +241,134 @@ function validateFloat(value: unknown, property: FloatProperty, path: string[], 
 
 function validateUrl(value: unknown, path: string[], errors: ValidationError[]) {
   if (typeof value !== 'object' || value === null) {
-    addError(errors, path, `Expected url object, received ${typeOf(value)}`, 'object', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected url object, received ${typeOf(value)}`,
+      'object',
+      typeOf(value),
+    );
   }
 }
 
 function validateRichText(value: unknown, path: string[], errors: ValidationError[]) {
   if (typeof value !== 'object' || value === null) {
-    addError(errors, path, `Expected richText object, received ${typeOf(value)}`, 'object', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected richText object, received ${typeOf(value)}`,
+      'object',
+      typeOf(value),
+    );
     return;
   }
   const obj = value as Record<string, unknown>;
   if (obj.html != null && typeof obj.html !== 'string') {
-    addError(errors, [...path, 'html'], `Expected string or null, received ${typeOf(obj.html)}`, 'string', typeOf(obj.html));
+    addError(
+      errors,
+      [...path, 'html'],
+      `Expected string or null, received ${typeOf(obj.html)}`,
+      'string',
+      typeOf(obj.html),
+    );
   }
   if (obj.json != null && typeof obj.json !== 'object') {
-    addError(errors, [...path, 'json'], `Expected object or null, received ${typeOf(obj.json)}`, 'object', typeOf(obj.json));
+    addError(
+      errors,
+      [...path, 'json'],
+      `Expected object or null, received ${typeOf(obj.json)}`,
+      'object',
+      typeOf(obj.json),
+    );
   }
 }
 
 function validateLink(value: unknown, path: string[], errors: ValidationError[]) {
   if (typeof value !== 'object' || value === null) {
-    addError(errors, path, `Expected link object, received ${typeOf(value)}`, 'object', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected link object, received ${typeOf(value)}`,
+      'object',
+      typeOf(value),
+    );
   }
 }
 
-function validateContentReference(value: unknown, path: string[], errors: ValidationError[]) {
+function validateContentReference(
+  value: unknown,
+  path: string[],
+  errors: ValidationError[],
+) {
   if (typeof value !== 'object' || value === null) {
-    addError(errors, path, `Expected contentReference object, received ${typeOf(value)}`, 'object', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected contentReference object, received ${typeOf(value)}`,
+      'object',
+      typeOf(value),
+    );
     return;
   }
   const obj = value as Record<string, unknown>;
   if (obj.key != null && typeof obj.key !== 'string') {
-    addError(errors, [...path, 'key'], `Expected string or null, received ${typeOf(obj.key)}`, 'string', typeOf(obj.key));
+    addError(
+      errors,
+      [...path, 'key'],
+      `Expected string or null, received ${typeOf(obj.key)}`,
+      'string',
+      typeOf(obj.key),
+    );
   }
 }
 
 function validateContent(value: unknown, path: string[], errors: ValidationError[]) {
   if (typeof value !== 'object' || value === null) {
-    addError(errors, path, `Expected content object, received ${typeOf(value)}`, 'object', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected content object, received ${typeOf(value)}`,
+      'object',
+      typeOf(value),
+    );
     return;
   }
   const obj = value as Record<string, unknown>;
   if (obj.__typename != null && typeof obj.__typename !== 'string') {
-    addError(errors, [...path, '__typename'], `Expected string or null, received ${typeOf(obj.__typename)}`, 'string', typeOf(obj.__typename));
+    addError(
+      errors,
+      [...path, '__typename'],
+      `Expected string or null, received ${typeOf(obj.__typename)}`,
+      'string',
+      typeOf(obj.__typename),
+    );
   }
   if (obj.__viewname != null && typeof obj.__viewname !== 'string') {
-    addError(errors, [...path, '__viewname'], `Expected string or null, received ${typeOf(obj.__viewname)}`, 'string', typeOf(obj.__viewname));
+    addError(
+      errors,
+      [...path, '__viewname'],
+      `Expected string or null, received ${typeOf(obj.__viewname)}`,
+      'string',
+      typeOf(obj.__viewname),
+    );
   }
 }
 
-function validateComponent(value: unknown, ct: AnyContentType, path: string[], errors: ValidationError[], visited: Set<string>) {
+function validateComponent(
+  value: unknown,
+  ct: AnyContentType,
+  path: string[],
+  errors: ValidationError[],
+  visited: Set<string>,
+) {
   if (typeof value !== 'object' || value === null) {
-    addError(errors, path, `Expected component object, received ${typeOf(value)}`, 'object', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected component object, received ${typeOf(value)}`,
+      'object',
+      typeOf(value),
+    );
     return;
   }
   if (visited.has(ct.key)) return;
@@ -262,9 +384,21 @@ function validateComponent(value: unknown, ct: AnyContentType, path: string[], e
   }
 }
 
-function validateArray(value: unknown, property: ArrayProperty<ArrayItems>, path: string[], errors: ValidationError[], visited: Set<string>) {
+function validateArray(
+  value: unknown,
+  property: ArrayProperty<ArrayItems>,
+  path: string[],
+  errors: ValidationError[],
+  visited: Set<string>,
+) {
   if (!Array.isArray(value)) {
-    addError(errors, path, `Expected array, received ${typeOf(value)}`, 'array', typeOf(value));
+    addError(
+      errors,
+      path,
+      `Expected array, received ${typeOf(value)}`,
+      'array',
+      typeOf(value),
+    );
     return;
   }
   if (property.minItems !== undefined && value.length < property.minItems) {
@@ -278,7 +412,13 @@ function validateArray(value: unknown, property: ArrayProperty<ArrayItems>, path
   }
 }
 
-function validateProperty(value: unknown, property: AnyProperty, path: string[], errors: ValidationError[], visited: Set<string>) {
+function validateProperty(
+  value: unknown,
+  property: AnyProperty,
+  path: string[],
+  errors: ValidationError[],
+  visited: Set<string>,
+) {
   if (value === null || value === undefined) return;
 
   switch (property.type) {
@@ -287,7 +427,13 @@ function validateProperty(value: unknown, property: AnyProperty, path: string[],
       break;
     case 'boolean':
       if (typeof value !== 'boolean') {
-        addError(errors, path, `Expected boolean, received ${typeOf(value)}`, 'boolean', typeOf(value));
+        addError(
+          errors,
+          path,
+          `Expected boolean, received ${typeOf(value)}`,
+          'boolean',
+          typeOf(value),
+        );
       }
       break;
     case 'integer':
@@ -298,7 +444,13 @@ function validateProperty(value: unknown, property: AnyProperty, path: string[],
       break;
     case 'dateTime':
       if (typeof value !== 'string') {
-        addError(errors, path, `Expected dateTime string, received ${typeOf(value)}`, 'string', typeOf(value));
+        addError(
+          errors,
+          path,
+          `Expected dateTime string, received ${typeOf(value)}`,
+          'string',
+          typeOf(value),
+        );
       }
       break;
     case 'binary':
@@ -320,11 +472,16 @@ function validateProperty(value: unknown, property: AnyProperty, path: string[],
       validateContent(value, path, errors);
       break;
     case 'component': {
-      // ponytail: typed as AnyContentType, but a content type key string can arrive at runtime
       const ct: AnyContentType | string = property.contentType;
       const resolved = typeof ct === 'string' ? getContentType(ct) : ct;
       if (resolved && 'baseType' in resolved && resolved.baseType) {
-        validateComponent(value, resolved as AnyContentType, path, errors, new Set(visited));
+        validateComponent(
+          value,
+          resolved as AnyContentType,
+          path,
+          errors,
+          new Set(visited),
+        );
       }
       break;
     }


### PR DESCRIPTION
- Update the validation in CLI and throw error for properties content and contentReference.
- Add typescript guards for properties content and contentReference