### PR TITLE
CMS-49490 Fix circular fragment references in GraphQL query generation

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/__test__/createQuery.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/createQuery.test.ts
@@ -251,7 +251,7 @@ describe('createFragment() with `content` properties. Base types', () => {
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
         "fragment r1 on r1 { __typename ..._IContent }",
-        "fragment r2 on r2 { __typename r2__p1:p1 { __typename ...r1 ...r2 } ..._IContent }",
+        "fragment r2 on r2 { __typename r2__p1:p1 { __typename ...r1 } ..._IContent }",
         "fragment ct1 on ct1 { __typename ct1__p1:p1 { __typename ...r1 ...r2 } ..._IContent }",
       ]
     `);
@@ -355,7 +355,7 @@ describe('createFragment() with `content` properties. Allowed and restricted typ
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
         "fragment r1 on r1 { __typename ..._IContent }",
         "fragment r3 on r3 { __typename ..._IContent }",
-        "fragment ct1 on ct1 { __typename ct1__p1:p1 { __typename ...r1 ...r3 ...ct1 } ..._IContent }",
+        "fragment ct1 on ct1 { __typename ct1__p1:p1 { __typename ...r1 ...r3 } ..._IContent }",
       ]
     `);
   });
@@ -421,7 +421,7 @@ describe('createFragment() with `content` properties. Allowed and restricted typ
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
         "fragment r1 on r1 { __typename ..._IContent }",
         "fragment r2 on r2 { __typename ..._IContent }",
-        "fragment ct1 on ct1 { __typename ct1__p1:p1 { __typename ...r1 ...r2 ...ct1 } ..._IContent }",
+        "fragment ct1 on ct1 { __typename ct1__p1:p1 { __typename ...r1 ...r2 } ..._IContent }",
       ]
     `);
   });
@@ -446,7 +446,7 @@ describe('createFragment() with self references', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment r1 on r1 { __typename r1__p1:p1 { __typename ...r1 } ..._IContent }",
+        "fragment r1 on r1 { __typename r1__p1:p1 { __typename } ..._IContent }",
       ]
     `);
   });
@@ -469,7 +469,7 @@ describe('createFragment() with self references', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment r1 on r1 { __typename r1__p1:p1 { __typename ...r1 } ..._IContent }",
+        "fragment r1 on r1 { __typename r1__p1:p1 { __typename } ..._IContent }",
       ]
     `);
   });
@@ -492,7 +492,7 @@ describe('createFragment() with self references', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment r1 on r1 { __typename r1__p1:p1 { __typename ...r1 } ..._IContent }",
+        "fragment r1 on r1 { __typename r1__p1:p1 { __typename } ..._IContent }",
       ]
     `);
   });
@@ -522,7 +522,7 @@ describe('createFragment() with self references', () => {
         "fragment ContentUrl on ContentUrl { type default hierarchical internal graph base }",
         "fragment IContentMetadata on IContentMetadata { key locale fallbackForLocale version displayName url {...ContentUrl} types published status created lastModified sortOrder variation ...MediaMetadata ...ItemMetadata ...InstanceMetadata }",
         "fragment _IContent on _IContent { _id _metadata {...IContentMetadata} }",
-        "fragment r1 on r1 { __typename r1__p1:p1 { __typename ...r1 } ..._IContent }",
+        "fragment r1 on r1 { __typename r1__p1:p1 { __typename } ..._IContent }",
       ]
     `);
   });
@@ -700,7 +700,7 @@ describe('createFragment() with string key references', () => {
       f.startsWith('fragment ctB '),
     );
     expect(ctAFragment).toContain('...ctB');
-    expect(ctBFragment).toContain('...ctA');
+    expect(ctBFragment).not.toContain('...ctA');
   });
 
   test('mix of ContentType objects and string keys', async () => {
@@ -732,6 +732,63 @@ describe('createFragment() with string key references', () => {
     );
     expect(ctCFragment).toContain('...ctA');
     expect(ctCFragment).toContain('...ctB');
+  });
+});
+
+describe('createFragment() circular reference prevention', () => {
+  test('array of content without allowedTypes does not self-reference', async () => {
+    const mapPage = contentType({
+      key: 'MapPage',
+      displayName: 'Map Page',
+      baseType: '_page',
+      properties: {
+        MainMap: { type: 'array', items: { type: 'content', restrictedTypes: [] } },
+      },
+    });
+    const articlePage = contentType({
+      key: 'ArticlePage',
+      displayName: 'Article Page',
+      baseType: '_page',
+      properties: {
+        BodyContent: { type: 'array', items: { type: 'content', restrictedTypes: [] } },
+      },
+    });
+
+    initContentTypeRegistry([mapPage, articlePage]);
+    const result = createFragment('MapPage');
+    const mapFragment = result.fragments.find((f: string) => f.startsWith('fragment MapPage '));
+    const articleFragment = result.fragments.find((f: string) =>
+      f.startsWith('fragment ArticlePage '),
+    );
+
+    expect(mapFragment).toContain('...ArticlePage');
+    expect(mapFragment).not.toContain('...MapPage');
+    expect(articleFragment).not.toContain('...ArticlePage');
+    expect(articleFragment).not.toContain('...MapPage');
+  });
+
+  test('sibling content properties still include all non-ancestor types', async () => {
+    const block = contentType({
+      key: 'Block',
+      displayName: 'Block',
+      baseType: '_component',
+    });
+    const page = contentType({
+      key: 'Page',
+      displayName: 'Page',
+      baseType: '_page',
+      properties: {
+        area1: { type: 'content', allowedTypes: [block] },
+        area2: { type: 'content', allowedTypes: [block] },
+      },
+    });
+
+    initContentTypeRegistry([block, page]);
+    const result = createFragment('Page');
+    const pageFragment = result.fragments.find((f: string) => f.startsWith('fragment Page '));
+
+    expect(pageFragment).toContain('area1 { __typename ...Block }');
+    expect(pageFragment).toContain('area2 { __typename ...Block }');
   });
 });
 

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -249,6 +249,7 @@ export const createFragment = (
 
   if (visited.size === 0) refreshCache();
   visited.add(fragmentName);
+  ctx.ancestors.add(fragmentName);
 
   // Create telemetry span only at root level (not for recursive calls)
   const isRootCall = visited.size === 1;
@@ -345,6 +346,7 @@ export const createFragment = (
     span.end();
   }
 
+  ctx.ancestors.delete(fragmentName);
   return result;
 };
 

--- a/packages/optimizely-cms-sdk/src/util/queryUtils.ts
+++ b/packages/optimizely-cms-sdk/src/util/queryUtils.ts
@@ -117,6 +117,11 @@ export type QueryContext = {
    * have the field.
    */
   sectionTypes?: ReadonlySet<string>;
+  /**
+   * Tracks the ancestor fragment chain during recursive fragment generation
+   * to prevent circular fragment references.
+   */
+  ancestors: Set<string>;
 };
 
 /**
@@ -158,6 +163,7 @@ export const createQueryContext = (
   formsEnabled: options.formsEnabled ?? false,
   typeFilter: options.typeFilter,
   sectionTypes: options.sectionTypes,
+  ancestors: options.ancestors ?? new Set(),
 });
 
 export type FragmentInfo = {
@@ -389,7 +395,7 @@ const handleContentProperty: PropertyHandler = (
   visited: Set<string>,
   ctx: QueryContext,
 ) => {
-  const { expandContracts, typeFilter } = ctx;
+  const { expandContracts, typeFilter, ancestors } = ctx;
   const resolved = resolveAllowedTypes(
     (property as any).allowedTypes,
     (property as any).restrictedTypes,
@@ -416,19 +422,25 @@ const handleContentProperty: PropertyHandler = (
   const subfields = ['__typename'];
 
   typesToInclude.forEach(key => {
+    const strippedKey = stripSourcePrefix(key);
     const result = createFragmentFor(key);
     includesDamAssetsFragments =
       includesDamAssetsFragments || result.includesDamAssetsFragments;
     extraFragments.push(...result.fragments);
-    subfields.push(`...${stripSourcePrefix(key)}`);
+    if (!ancestors?.has(strippedKey)) {
+      subfields.push(`...${strippedKey}`);
+    }
   });
 
   contractsToInclude.forEach(contractKey => {
+    const strippedKey = stripSourcePrefix(contractKey);
     const result = createFragmentFor(contractKey);
     includesDamAssetsFragments =
       includesDamAssetsFragments || result.includesDamAssetsFragments;
     extraFragments.push(...result.fragments);
-    subfields.push(`...${stripSourcePrefix(contractKey)}`);
+    if (!ancestors?.has(strippedKey)) {
+      subfields.push(`...${strippedKey}`);
+    }
   });
 
   const uniqueSubfields = [...new Set(subfields)].join(' ');
@@ -505,8 +517,6 @@ const handleArrayProperty: PropertyHandler = (
   visited: Set<string>,
   ctx: QueryContext,
 ) => {
-  // Forwards the whole context, which covers main's fix for `expandContracts`
-  // being dropped here (CMS-54935) along with every other query-wide setting.
   return convertProperty(name, (property as any).items, rootName, suffix, visited, ctx);
 };
 


### PR DESCRIPTION
When content-type array properties had no explicit allowedTypes/restrictedTypes, resolveAllowedTypes() returned all registered types including the type being processed. The spread reference (...TypeName) was added unconditionally, creating circular fragments that GraphQL rejects.

Added an ancestors set to track the current recursion stack separately from the visited set. Spread references are now skipped for ancestor types (preventing both direct self-references and indirect cycles) while sibling types that were already visited in a different branch still get their spread references correctly.

Bug: CMS-49490