### PR TITLE
CMS-55078 Add displayMode property to content types for editing interface control

### DIFF
--- a/.changeset/cool-pugs-hide.md
+++ b/.changeset/cool-pugs-hide.md
@@ -1,0 +1,6 @@
+---
+'@optimizely/cms-sdk': minor
+'@optimizely/cms-cli': minor
+---
+
+Add `displayMode` to content type properties. Set `displayMode: 'hidden'` to hide a property from the editing interface. Defaults to `'available'` when not set. `opti-cms config pull` keeps `displayMode: 'hidden'` in generated content types and omits the `'available'` default.

--- a/docs/3-modelling.md
+++ b/docs/3-modelling.md
@@ -240,6 +240,25 @@ properties: {
 }
 ```
 
+### Display Mode
+
+The `displayMode` field controls how the property is shown in the editing interface:
+
+- **`'available'`** (default) - The property is available for editing
+- **`'hidden'`** - The property is not shown in the editing interface
+
+The value is still stored and queryable; only the editing UI is affected.
+
+```ts
+properties: {
+  title: { type: 'string' },
+  internalId: {
+    type: 'string',
+    displayMode: 'hidden', // Set by code, not by editors
+  },
+}
+```
+
 ### Content Relationships
 
 For `content` and `contentReference` properties, use `allowedTypes` and `restrictedTypes` to control which content types can be referenced:

--- a/packages/optimizely-cms-cli/src/tests/generate.test.ts
+++ b/packages/optimizely-cms-cli/src/tests/generate.test.ts
@@ -183,12 +183,19 @@ describe('generateContentCode', () => {
       baseType: '_page',
       isContract: false,
       properties: {
-        title: { type: 'string', isLocalized: false, isRequired: false, sortOrder: 0 },
+        title: {
+          type: 'string',
+          isLocalized: false,
+          isRequired: false,
+          sortOrder: 0,
+          displayMode: 'available',
+        },
         description: {
           type: 'string',
           isLocalized: true,
           isRequired: true,
           sortOrder: 1,
+          displayMode: 'hidden',
         },
       },
     };
@@ -197,9 +204,11 @@ describe('generateContentCode', () => {
     expect(result).toContain('isLocalized: true');
     expect(result).toContain('isRequired: true');
     expect(result).toContain('sortOrder: 1');
+    expect(result).toContain("displayMode: 'hidden'");
     expect(result).not.toContain('isLocalized: false');
     expect(result).not.toContain('isRequired: false');
     expect(result).not.toContain('sortOrder: 0');
+    expect(result).not.toContain('displayMode: \'available\'');
   });
 });
 

--- a/packages/optimizely-cms-cli/src/utils/generate.ts
+++ b/packages/optimizely-cms-cli/src/utils/generate.ts
@@ -387,6 +387,7 @@ const skipPropertyConditions: Record<string, (it: any) => boolean> = {
   isLocalized: (it: any) => it === false,
   isRequired: (it: any) => it === false,
   sortOrder: (it: any) => it === 0,
+  displayMode: (it: any) => it === 'available',
   mayContainTypes: (it: any) => it?.length === 0,
   extends: (it: any) => it?.length === 0,
   contentType: (it: any) => it === undefined,

--- a/packages/optimizely-cms-cli/src/utils/manifest.ts
+++ b/packages/optimizely-cms-cli/src/utils/manifest.ts
@@ -67,6 +67,7 @@ export namespace ContentTypeProperties {
     group?: string;
     sortOrder?: number;
     indexingType?: string;
+    displayMode?: string;
   };
 
   // Enum wrapper type supporting multiple formats:

--- a/packages/optimizely-cms-sdk/src/model/properties.ts
+++ b/packages/optimizely-cms-sdk/src/model/properties.ts
@@ -8,6 +8,9 @@ export type INDEX_TYPE = 'disabled' | 'queryable' | 'searchable';
 
 export type RICHTEXT_PRESET = 'default' | 'expanded' | 'standard' | 'minimal';
 
+/** How a property is displayed in the editing interface. Defaults to `available`. */
+export type DISPLAY_MODE = 'available' | 'hidden';
+
 /** A "Base" content type property that includes all common attributes for all content type properties */
 type BaseProperty = {
   format?: string;
@@ -18,6 +21,7 @@ type BaseProperty = {
   group?: PropertyGroupKey;
   sortOrder?: number;
   indexingType?: INDEX_TYPE;
+  displayMode?: DISPLAY_MODE;
 };
 
 type WithEnum<T> = {

--- a/plugins/optimizely-cms-skills/skills/optimizely-model/SKILL.md
+++ b/plugins/optimizely-cms-skills/skills/optimizely-model/SKILL.md
@@ -98,6 +98,7 @@ See `references/property-types.md` for the complete list with examples.
 | `isRequired` | Must have a value | `true`, `false` |
 | `isLocalized` | Different value per language | `true`, `false` |
 | `indexingType` | Search indexing behavior | `'searchable'`, `'queryable'` |
+| `displayMode` | Visibility in editing UI | `'available'`, `'hidden'` |
 
 **When user says** → **Use this field**:
 - "display name", "label" → `displayName`
@@ -106,6 +107,7 @@ See `references/property-types.md` for the complete list with examples.
 - "sort order", "sort index", "order" → `sortOrder`
 - "group", "tab" → `group`
 - "searchable" → `indexingType: 'searchable'`
+- "hidden", "hide from editors", "not editable" → `displayMode: 'hidden'`
 - "required", "mandatory" → `isRequired: true`
 
 **Example with metadata:**

--- a/plugins/optimizely-cms-skills/skills/optimizely-model/references/property-types.md
+++ b/plugins/optimizely-cms-skills/skills/optimizely-model/references/property-types.md
@@ -387,6 +387,7 @@ All property types support these common metadata fields:
 | `isRequired` | boolean | Whether property must have a value | `true`, `false` |
 | `isLocalized` | boolean | Whether property has different values per language/culture | `true`, `false` |
 | `indexingType` | string | How property is indexed for search | `'searchable'`, `'queryable'` |
+| `displayMode` | string | How property is displayed in the editing interface | `'available'`, `'hidden'` |
 
 **Complete example with all metadata:**
 
@@ -418,6 +419,7 @@ title: {
 | "searchable", "indexed for search" | `indexingType` | `'searchable'` |
 | "queryable", "filterable" | `indexingType` | `'queryable'` |
 | "required", "mandatory", "must have value" | `isRequired` | `true` |
+| "hidden", "hide from editors", "not editable" | `displayMode` | `'hidden'` |
 
 **Example mappings:**
 


### PR DESCRIPTION
- Add enum for `displayMode` with values `available`, `hidden`.
- Populate `displayMode` when **cotentTypes** are pulled via CLI.
- Update SKILLS and docs about `displayMode`.