### PR TITLE
Normalize CMS decoration attribute to text-decoration style

### DIFF
--- a/packages/optimizely-cms-sdk/src/components/richText/renderer.ts
+++ b/packages/optimizely-cms-sdk/src/components/richText/renderer.ts
@@ -199,10 +199,6 @@ export type RendererConfig<TElement = unknown, TText = unknown> = {
   decodeHtmlEntities?: boolean;
 };
 
-const CMS_ATTRIBUTE_ALIASES: Record<string, string> = {
-  decoration: 'text-decoration',
-};
-
 // Reserved props that should not be passed as HTML attributes
 export const RESERVED_PROPS = new Set(['url', 'children', 'type', 'internal', 'base']);
 
@@ -212,11 +208,9 @@ export const RESERVED_PROPS = new Set(['url', 'children', 'type', 'internal', 'b
 export function mapAttributes(node: Element): Record<string, unknown> {
   const nodeProps: Record<string, unknown> = {};
 
-  // Copy non-reserved props verbatim, normalizing CMS shorthand keys
   Object.keys(node).forEach(k => {
     if (!RESERVED_PROPS.has(k)) {
-      const key = CMS_ATTRIBUTE_ALIASES[k] ?? k;
-      nodeProps[key] = node[k as keyof Element];
+      nodeProps[k] = node[k as keyof Element];
     }
   });
 

--- a/packages/optimizely-cms-sdk/src/components/richText/renderer.ts
+++ b/packages/optimizely-cms-sdk/src/components/richText/renderer.ts
@@ -199,6 +199,10 @@ export type RendererConfig<TElement = unknown, TText = unknown> = {
   decodeHtmlEntities?: boolean;
 };
 
+const CMS_ATTRIBUTE_ALIASES: Record<string, string> = {
+  decoration: 'text-decoration',
+};
+
 // Reserved props that should not be passed as HTML attributes
 export const RESERVED_PROPS = new Set(['url', 'children', 'type', 'internal', 'base']);
 
@@ -208,10 +212,11 @@ export const RESERVED_PROPS = new Set(['url', 'children', 'type', 'internal', 'b
 export function mapAttributes(node: Element): Record<string, unknown> {
   const nodeProps: Record<string, unknown> = {};
 
-  // Copy non-reserved props verbatim
+  // Copy non-reserved props verbatim, normalizing CMS shorthand keys
   Object.keys(node).forEach(k => {
     if (!RESERVED_PROPS.has(k)) {
-      nodeProps[k] = node[k as keyof Element];
+      const key = CMS_ATTRIBUTE_ALIASES[k] ?? k;
+      nodeProps[key] = node[k as keyof Element];
     }
   });
 

--- a/packages/optimizely-cms-sdk/src/react/__test__/RichText.test.tsx
+++ b/packages/optimizely-cms-sdk/src/react/__test__/RichText.test.tsx
@@ -10,6 +10,7 @@ import {
   htmlEntitiesContent,
   unknownElementContent,
   markedTextContent,
+  styledSpanContent,
 } from './mockData.js';
 
 describe('RichText Component', () => {
@@ -55,5 +56,12 @@ describe('RichText Component', () => {
     expect(screen.getByText('underlined text').tagName.toLowerCase()).toBe('u');
     expect(screen.getByText('code text').tagName.toLowerCase()).toBe('code'); // Fixed: now correctly renders as <code>
     expect(screen.getByText('strikethrough text').tagName.toLowerCase()).toBe('s');
+  });
+
+  it('should render styled span with decoration as text-decoration style', () => {
+    render(<RichText content={styledSpanContent} />);
+    const el = screen.getByText('Hello world');
+    expect(el.tagName.toLowerCase()).toBe('span');
+    expect(el).toHaveStyle('text-decoration: underline');
   });
 });

--- a/packages/optimizely-cms-sdk/src/react/__test__/RichText.test.tsx
+++ b/packages/optimizely-cms-sdk/src/react/__test__/RichText.test.tsx
@@ -11,6 +11,7 @@ import {
   unknownElementContent,
   markedTextContent,
   styledSpanContent,
+  styledSpanKebabCaseContent,
 } from './mockData.js';
 
 describe('RichText Component', () => {
@@ -58,8 +59,15 @@ describe('RichText Component', () => {
     expect(screen.getByText('strikethrough text').tagName.toLowerCase()).toBe('s');
   });
 
-  it('should render styled span with decoration as text-decoration style', () => {
+  it('should render styled span with decoration as text-decoration style (old format)', () => {
     render(<RichText content={styledSpanContent} />);
+    const el = screen.getByText('Hello world');
+    expect(el.tagName.toLowerCase()).toBe('span');
+    expect(el).toHaveStyle('text-decoration: underline');
+  });
+
+  it('should render styled span with text-decoration as text-decoration style (new kebab-case format)', () => {
+    render(<RichText content={styledSpanKebabCaseContent} />);
     const el = screen.getByText('Hello world');
     expect(el.tagName.toLowerCase()).toBe('span');
     expect(el).toHaveStyle('text-decoration: underline');

--- a/packages/optimizely-cms-sdk/src/react/__test__/mockData.ts
+++ b/packages/optimizely-cms-sdk/src/react/__test__/mockData.ts
@@ -184,7 +184,7 @@ export const markedTextContent = {
   ] as Node[],
 };
 
-// Element node with CMS "decoration" attribute (GitHub issue #495)
+// Element node with CMS "decoration" attribute - old format without prefix (GitHub issue #495)
 export const styledSpanContent = {
   type: 'richText' as const,
   children: [
@@ -194,6 +194,23 @@ export const styledSpanContent = {
         {
           type: 'span',
           decoration: 'underline',
+          children: [{ text: 'Hello world' }],
+        },
+      ],
+    },
+  ] as Node[],
+};
+
+// Element node with CMS "text-decoration" attribute - new kebab-case format (GitHub issue #495)
+export const styledSpanKebabCaseContent = {
+  type: 'richText' as const,
+  children: [
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'span',
+          'text-decoration': 'underline',
           children: [{ text: 'Hello world' }],
         },
       ],

--- a/packages/optimizely-cms-sdk/src/react/__test__/mockData.ts
+++ b/packages/optimizely-cms-sdk/src/react/__test__/mockData.ts
@@ -183,3 +183,20 @@ export const markedTextContent = {
     },
   ] as Node[],
 };
+
+// Element node with CMS "decoration" attribute (GitHub issue #495)
+export const styledSpanContent = {
+  type: 'richText' as const,
+  children: [
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'span',
+          decoration: 'underline',
+          children: [{ text: 'Hello world' }],
+        },
+      ],
+    },
+  ] as Node[],
+};

--- a/packages/optimizely-cms-sdk/src/react/richText/lib.ts
+++ b/packages/optimizely-cms-sdk/src/react/richText/lib.ts
@@ -421,9 +421,15 @@ export function toReactProps(attributes: Record<string, unknown>, elementType?: 
       }
     }
 
-    // Handle other CSS properties - move them to style object
-    if (CSS_PROPERTIES.has(key.toLowerCase())) {
-      const camelKey = kebabToCamelCase(key);
+    // Handle CSS properties - move them to style object.
+    // Also resolve old CMS shorthand keys missing the "text-" prefix
+    // (e.g. "decoration" -> "text-decoration").
+    const lowerKey = key.toLowerCase();
+    const cssKey = CSS_PROPERTIES.has(lowerKey) ? lowerKey
+      : CSS_PROPERTIES.has(`text-${lowerKey}`) ? `text-${lowerKey}`
+      : undefined;
+    if (cssKey) {
+      const camelKey = kebabToCamelCase(cssKey);
       styleProps[camelKey] = String(value);
       continue;
     }


### PR DESCRIPTION
The CMS emits "decoration" as an attribute key on span elements, but toReactProps() only recognizes the standard "text-decoration" CSS property. This caused underlined text to render as <span decoration="underline"> instead of <span style="text-decoration: underline;">.

CMS-55098