### PR TITLE
CMS-55406 Fix property inference for content types extending contracts without properties

### DIFF
--- a/.changeset/tall-camels-repeat.md
+++ b/.changeset/tall-camels-repeat.md
@@ -1,0 +1,5 @@
+---
+'@optimizely/cms-sdk': patch
+---
+
+Fix property inference for content types extending a contract without properties

--- a/packages/optimizely-cms-sdk/src/infer.test-d.ts
+++ b/packages/optimizely-cms-sdk/src/infer.test-d.ts
@@ -1,6 +1,6 @@
 import { test, expectTypeOf } from 'vitest';
 import type { ContentProps, InferredAssetMetadata, InferredImageMetadata } from './infer.js';
-import { contentType } from './model/index.js';
+import { contentType, contract } from './model/index.js';
 
 test('ContentProps works for non-content type', () => {
   expectTypeOf<ContentProps<number>>().toBeUnknown();
@@ -174,4 +174,41 @@ test('ContentProps infers JsonValue for JSON properties', () => {
 
   type Result = ContentProps<typeof c1>;
   expectTypeOf<Result['settings']>().not.toBeAny();
+});
+
+test('ContentProps keeps every property when extending contracts without properties', () => {
+  const Foo = contract({
+    key: 'Foo',
+    displayName: 'Foo',
+    properties: { foo: { type: 'string' } },
+  });
+  const EmptyProps = contract({
+    key: 'EmptyProps',
+    displayName: 'Empty properties',
+    properties: {},
+  });
+  const NoProps = contract({ key: 'NoProps', displayName: 'No properties' });
+
+  const withEmptyProps = contentType({
+    key: 'withEmptyProps',
+    displayName: 'With empty properties',
+    baseType: '_page',
+    extends: [Foo, EmptyProps],
+    properties: { test: { type: 'string' } },
+  });
+
+  const withNoProps = contentType({
+    key: 'withNoProps',
+    displayName: 'With no properties',
+    baseType: '_page',
+    extends: [Foo, NoProps],
+    properties: { test: { type: 'string' } },
+  });
+
+  // A contract without properties must not erase the other contracts' properties,
+  // nor the content type's own, nor add an index signature
+  expectTypeOf<ContentProps<typeof withEmptyProps>['foo']>().toEqualTypeOf<string | null>();
+  expectTypeOf<ContentProps<typeof withEmptyProps>['test']>().toEqualTypeOf<string | null>();
+  expectTypeOf<ContentProps<typeof withNoProps>['foo']>().toEqualTypeOf<string | null>();
+  expectTypeOf<ContentProps<typeof withNoProps>['test']>().toEqualTypeOf<string | null>();
 });

--- a/packages/optimizely-cms-sdk/src/model/contentTypeRegistry.ts
+++ b/packages/optimizely-cms-sdk/src/model/contentTypeRegistry.ts
@@ -1,6 +1,6 @@
-import { AnyContentType, Contract } from './contentTypes.js';
+import { AnyContentType, AnyContract } from './contentTypes.js';
 
-export type RegistryEntry = AnyContentType | Contract;
+export type RegistryEntry = AnyContentType | AnyContract;
 
 /** Types the application registered through `initContentTypeRegistry`. */
 let _registry: RegistryEntry[] = [];

--- a/packages/optimizely-cms-sdk/src/model/contentTypes.ts
+++ b/packages/optimizely-cms-sdk/src/model/contentTypes.ts
@@ -30,7 +30,7 @@ export type PropertiesRecord = Record<string, AnyProperty>;
 type BaseContentType = {
   key: string;
   displayName: string;
-  extends?: Contract | Array<Contract>;
+  extends?: AnyContract | Array<AnyContract>;
   properties?: PropertiesRecord;
 };
 
@@ -42,14 +42,24 @@ export type SuppliedContractValues<P extends PropertiesRecord = PropertiesRecord
   baseType?: never;
 };
 
-type InnerContractValues = {
+type InnerContractValues<P extends PropertiesRecord = PropertiesRecord> = {
   isContract: true;
   __type: 'contract';
+
+  /**
+   * Phantom property, never set at runtime. It makes `P` invariant, which stops
+   * TypeScript from subtype-reducing a union of contracts (as inferred from
+   * `extends: [A, B]`) down to the one with the fewest properties.
+   */
+  readonly __properties?: (properties: P) => P;
 };
 
 /** Represents the Contract type in CMS */
 export type Contract<P extends PropertiesRecord = PropertiesRecord> =
-  SuppliedContractValues<P> & InnerContractValues;
+  SuppliedContractValues<P> & InnerContractValues<P>;
+
+/** A contract with any properties. Use this when passing a contract around. */
+export type AnyContract = SuppliedContractValues & InnerContractValues<any>;
 
 /** Convert union to intersection type */
 type UnionToIntersection<U> =
@@ -142,7 +152,7 @@ export type ContentType<T extends AnyContentType = AnyContentType> = Omit<
 
 /** All possible content types for allowed and restricted fields */
 export type PermittedTypes =
-  | Contract
+  | AnyContract
   | ContentType
   | AnyContentType['baseType']
   | '_self'

--- a/packages/optimizely-cms-sdk/src/model/index.ts
+++ b/packages/optimizely-cms-sdk/src/model/index.ts
@@ -1,6 +1,7 @@
 import { BuildConfig } from './buildConfig.js';
 import {
   AnyContentType,
+  AnyContract,
   ContentType,
   Contract,
   PropertiesRecord,
@@ -69,7 +70,9 @@ export function contentType<T extends AnyContentType>(options: T): ContentType<T
  * });
  * ```
  */
-export function contract<P extends PropertiesRecord>(
+// `= {}` avoids falling back to `PropertiesRecord`'s index signature, which
+// would swallow other properties once merged
+export function contract<P extends PropertiesRecord = {}>(
   options: SuppliedContractValues<P>,
 ): Contract<P> {
   return { ...options, __type: 'contract', isContract: true };
@@ -105,7 +108,7 @@ export function isContentType(obj: unknown): obj is AnyContentType {
 /**
  * Checks if `obj` is a contract.
  */
-export function isContract(obj: unknown): obj is Contract {
+export function isContract(obj: unknown): obj is AnyContract {
   return (
     typeof obj === 'object' &&
     obj !== null &&
@@ -134,7 +137,7 @@ export function isDisplayTemplate(obj: unknown): obj is DisplayTemplate {
  * @param contract - The contract to search for
  * @returns Array of content types that extend the contract
  */
-export const findExtendingContentTypes = (contract: Contract): AnyContentType[] =>
+export const findExtendingContentTypes = (contract: AnyContract): AnyContentType[] =>
   getAllContentTypes().filter((entry): entry is AnyContentType => {
     if (!isContentType(entry)) return false;
 
@@ -157,6 +160,7 @@ export { init as initDisplayTemplateRegistry } from './displayTemplateRegistry.j
 // Re-export types needed for declaration file generation
 export type {
   AnyContentType,
+  AnyContract,
   BaseTypes,
   ComponentContentType,
   ContentType,


### PR DESCRIPTION
- Refactor `Contract` type and fix inferring properties.