### PR TITLE
CMS-55705 Add `_opuid` for inline components and enhance context handling

### DIFF
--- a/docs/3-modelling.md
+++ b/docs/3-modelling.md
@@ -215,6 +215,14 @@ const LandingPageType = contentType({
 
 The `component` type requires a `contentType` field specifying which component type to use.
 
+`component` can also be used as an array's `items`, for a repeated inline block with no CMS-level identity of its own (unlike `type: 'content'`/`allowedTypes`, which references real, independently-identified content and already has `_metadata.key`). Use each item's `_opuid` for the React `key` — the SDK fills it in for every array item, using `_metadata.key` when the item has one (content references) or a content-derived id when it doesn't (inline components):
+
+```tsx
+{content.highlights?.map(highlight => (
+  <OptimizelyComponent key={highlight._opuid} content={highlight} />
+))}
+```
+
 ### Indexing Types
 
 The `indexingType` field controls how the property is indexed for search:
@@ -586,8 +594,8 @@ import { OptimizelyComponent } from '@optimizely/cms-sdk/react/server';
 function FeedPage({ content }) {
   return (
     <div>
-      {content.featuredItems?.map((item, index) => (
-        <OptimizelyComponent key={index} content={item} />
+      {content.featuredItems?.map(item => (
+        <OptimizelyComponent key={item._opuid} content={item} />
       ))}
     </div>
   );

--- a/packages/optimizely-cms-sdk/src/graph/__test__/contentAreaForms.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/contentAreaForms.test.ts
@@ -23,6 +23,9 @@ const STEPS = [
   { __typename: 'CompositionStructureNode', nodeType: 'step', key: 'step-1' },
 ];
 
+/** `STEPS` as it comes back out: array items also get `_opuid` (see decorateWithContext). */
+const EXPECTED_STEPS = STEPS.map(step => ({ ...step, _opuid: expect.any(String) }));
+
 /** A container as it arrives inside a content area: no steps. */
 const nestedForm = () => ({
   __typename: 'OptiFormsContainerData',
@@ -82,7 +85,7 @@ describe('a form reached through a content area', () => {
   test('has its steps filled in', async () => {
     const page: any = await client.getContent({ key: 'page-1' });
 
-    expect(page.extras[0].nodes).toEqual(STEPS);
+    expect(page.extras[0].nodes).toEqual(EXPECTED_STEPS);
   });
 
   test('is fetched on its own, since the page query cannot carry them', async () => {
@@ -169,8 +172,8 @@ describe('the same shared form referenced twice', () => {
 
     const page: any = await client.getContent({ key: 'page-1' });
 
-    expect(page.extras[0].nodes).toEqual(STEPS);
-    expect(page.extras[1].nodes).toEqual(STEPS);
+    expect(page.extras[0].nodes).toEqual(EXPECTED_STEPS);
+    expect(page.extras[1].nodes).toEqual(EXPECTED_STEPS);
   });
 });
 describe('the cost of filling forms in', () => {
@@ -251,7 +254,7 @@ describe('a form whose steps already arrived', () => {
 
     const form: any = await client.getContent({ key: 'form-1' });
 
-    expect(form.nodes).toEqual(STEPS);
+    expect(form.nodes).toEqual(EXPECTED_STEPS);
     expect(request.mock.calls).toHaveLength(2);
   });
 

--- a/packages/optimizely-cms-sdk/src/graph/__test__/context.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__test__/context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, vi, afterEach } from 'vitest';
-import { removeTypePrefix, GraphClient } from '../index.js';
+import { removeTypePrefix, decorateWithContext, GraphClient } from '../index.js';
 import {
   configureAdapter,
   getContext,
@@ -81,6 +81,38 @@ describe('removeTypePrefix()', () => {
     };
 
     expect(removeTypePrefix(input)).toStrictEqual(input);
+  });
+});
+
+describe('decorateWithContext() - _opuid', () => {
+  const params = { ctx: 'published', preview_token: 'token-123' } as any;
+
+  test('uses _metadata.key when the item has CMS identity', () => {
+    const input = [{ __typename: 'Notice', _metadata: { key: 'abc123' }, title: 'Hi' }];
+    const [item] = decorateWithContext(input, params);
+    expect(item._opuid).toBe('abc123');
+  });
+
+  test('falls back to a content-derived hash when _metadata is absent', () => {
+    const input = [{ __typename: 'Hero', title: 'Same content' }];
+    const [item] = decorateWithContext(input, params);
+    expect(item._opuid).toBeTypeOf('string');
+    expect(item._opuid.length).toBeGreaterThan(0);
+  });
+
+  test('hash is stable for identical content and differs for different content', () => {
+    const [a] = decorateWithContext([{ __typename: 'Hero', title: 'Same' }], params);
+    const [b] = decorateWithContext([{ __typename: 'Hero', title: 'Same' }], params);
+    const [c] = decorateWithContext([{ __typename: 'Hero', title: 'Different' }], params);
+    expect(a._opuid).toBe(b._opuid);
+    expect(a._opuid).not.toBe(c._opuid);
+  });
+
+  test('does not add _opuid to a non-array (single) content object', () => {
+    const input = { __typename: 'Hero', title: 'Standalone' };
+    const item = decorateWithContext(input, params);
+    expect(item._opuid).toBeUndefined();
+    expect(item.__context).toBeDefined();
   });
 });
 

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -29,6 +29,7 @@ import { setContext } from '../context/config.js';
 import { isContentTypeRegistered } from '../model/contentTypeRegistry.js';
 import { isFormContentType } from '../model/formContentTypes.js';
 import { contentTypeCanHoldForms, getCachedContentTypes } from '../util/queryUtils.js';
+import { stableKey } from '../util/stableKey.js';
 import { logError, SemanticAttributes } from '../telemetry/index.js';
 import {
   withRequestSpan,
@@ -210,10 +211,18 @@ const METADATA_OP_NAMES: Record<FilterShape, string> = {
   'by-path': 'GetContentMetadataByPath',
 };
 
-function getMetadataQuery(shape: FilterShape, variationMode: VariationMode = 'none'): string {
+function getMetadataQuery(
+  shape: FilterShape,
+  variationMode: VariationMode = 'none',
+): string {
   const varDecls = getFilterVarDecls(shape);
   const variationVars = getVariationVarDecls(variationMode);
-  const allVars = [varDecls, variationVars, '$formsWhere: _ExperienceWhereInput', '$withForms: Boolean!']
+  const allVars = [
+    varDecls,
+    variationVars,
+    '$formsWhere: _ExperienceWhereInput',
+    '$withForms: Boolean!',
+  ]
     .filter(Boolean)
     .join(', ');
   const whereClause = getFilterWhereClause(shape);
@@ -332,10 +341,7 @@ const LINKS_BODY = (linkType: 'PATH' | 'ITEMS') => `{
     }
   }`;
 
-function getLinksQuery(
-  opName: string,
-  shape: FilterShape,
-): string {
+function getLinksQuery(opName: string, shape: FilterShape): string {
   const filterVars = getFilterVarDecls(shape);
   const whereClause = getFilterWhereClause(shape);
   const allVars = [filterVars, '$locale: [Locales]'].sort().join(', ');
@@ -345,10 +351,7 @@ query ${opName}(${allVars}) {
 }`;
 }
 
-function getItemsQuery(
-  opName: string,
-  shape: FilterShape,
-): string {
+function getItemsQuery(opName: string, shape: FilterShape): string {
   const filterVars = getFilterVarDecls(shape);
   const whereClause = getFilterWhereClause(shape);
   const allVars = [filterVars, '$locale: [Locales]'].sort().join(', ');
@@ -357,7 +360,6 @@ query ${opName}(${allVars}) {
   _Content(${whereClause}, locale: $locale) ${LINKS_BODY('ITEMS')}
 }`;
 }
-
 
 type GetLinksResponse = {
   _Content: {
@@ -503,20 +505,33 @@ function findUnresolvedForms(value: any, found: any[] = [], seen = new Set()): a
   return found;
 }
 
-/** Adds an extra `__context` property next to each `__typename` property */
-function decorateWithContext(obj: any, params: PreviewParams): any {
+/**
+ * Adds `_opuid` (a stable React list key) to every array item, and, when `params`
+ * is given, `__context` to every `__typename` object (preview/edit mode only).
+ * Exported only for testing — not part of the user-facing API.
+ */
+export function decorateWithContext(
+  obj: any,
+  params: PreviewParams | null,
+  isArrayItem = false,
+): any {
   if (Array.isArray(obj)) {
-    return obj.map(e => decorateWithContext(e, params));
+    return obj.map(e => decorateWithContext(e, params, true));
   }
   if (typeof obj === 'object' && obj !== null) {
     for (const k in obj) {
       obj[k] = decorateWithContext(obj[k], params);
     }
     if ('__typename' in obj) {
-      obj.__context = {
-        edit: params.ctx === 'edit',
-        preview_token: params.preview_token,
-      };
+      if (isArrayItem) {
+        obj._opuid = obj._metadata?.key ?? stableKey(obj);
+      }
+      if (params) {
+        obj.__context = {
+          edit: params.ctx === 'edit',
+          preview_token: params.preview_token,
+        };
+      }
     }
   }
   return obj;
@@ -918,15 +933,18 @@ export class GraphClient {
           storedEnabled,
         )) as ItemsResponse<T>;
 
-        return Promise.all(
-          response?._Content?.items.map((item: unknown) =>
-            this.resolveFormNodes(liftSectionNodes(removeTypePrefix(item)), {
-              damEnabled,
-              sectionTypes,
-              cache: cacheEnabled,
-              slot: activeSlot,
-            }),
-          ) ?? [],
+        return decorateWithContext(
+          await Promise.all(
+            response?._Content?.items.map((item: unknown) =>
+              this.resolveFormNodes(liftSectionNodes(removeTypePrefix(item)), {
+                damEnabled,
+                sectionTypes,
+                cache: cacheEnabled,
+                slot: activeSlot,
+              }),
+            ) ?? [],
+          ),
+          null,
         );
       } catch (error) {
         if (error instanceof GraphMissingContentTypeError) {
@@ -1100,7 +1118,12 @@ export class GraphClient {
       if (!contentTypeName) {
         throw new GraphResponseError(
           `Content with key '${params.key}' could not be found. Verify it exists in the CMS.`,
-          { request: { variables: filter.variables, query: getMetadataQuery(filter.filterShape, 'all') } },
+          {
+            request: {
+              variables: filter.variables,
+              query: getMetadataQuery(filter.filterShape, 'all'),
+            },
+          },
         );
       }
 
@@ -1304,15 +1327,18 @@ export class GraphClient {
           storedEnabled,
         );
 
-        return this.resolveFormNodes(
-          liftSectionNodes(removeTypePrefix(response?._Content?.item)),
-          {
-            damEnabled,
-            sectionTypes,
-            previewToken,
-            cache: cacheEnabled,
-            slot: activeSlot,
-          },
+        return decorateWithContext(
+          await this.resolveFormNodes(
+            liftSectionNodes(removeTypePrefix(response?._Content?.item)),
+            {
+              damEnabled,
+              sectionTypes,
+              previewToken,
+              cache: cacheEnabled,
+              slot: activeSlot,
+            },
+          ),
+          null,
         );
       } catch (error) {
         if (error instanceof GraphMissingContentTypeError) {

--- a/packages/optimizely-cms-sdk/src/infer.ts
+++ b/packages/optimizely-cms-sdk/src/infer.ts
@@ -105,7 +105,7 @@ export type InferFromProperty<T extends AnyProperty> =
   : T extends FloatProperty ? number
   : T extends ContentReferenceProperty ? InferredContentReference
   : T extends ArrayProperty<infer E> ? InferFromProperty<E>[]
-  : T extends ContentProperty ? {__typename: string, __viewname: string}
+  : T extends ContentProperty ? {__typename: string, __viewname: string, _opuid?: string}
   : T extends ComponentProperty<infer E> ? ContentProps<E>
   : unknown
 
@@ -124,6 +124,9 @@ export type InferredImageMetadata = {
 export type InferredBase = {
   _id: string;
   _metadata: InferredContentMetadata;
+
+  /** Unique id added by `decorateWithContext`; can be used as a React `key` */
+  _opuid?: string;
 
   // Properties that don't come from Graph are prefixed with double-underscores
   __typename: string;

--- a/packages/optimizely-cms-sdk/src/util/stableKey.ts
+++ b/packages/optimizely-cms-sdk/src/util/stableKey.ts
@@ -1,0 +1,12 @@
+/** Generates a unique id for inline array content items with no CMS identity; used to build `_opuid`. */
+export function stableKey(item: unknown): string {
+  const str = JSON.stringify(item, (key, value) =>
+    key.startsWith('__') ? undefined : value,
+  );
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}

--- a/samples/fx-integration/src/app/en/[...slug]/page.tsx
+++ b/samples/fx-integration/src/app/en/[...slug]/page.tsx
@@ -14,7 +14,7 @@ function returnFirst<T>(content: T[]) {
     notFound();
   }
 
-  return content[0];
+  return content[0] as any;
 }
 
 export default async function Page({ params }: Props) {

--- a/templates/alloy/src/components/News.tsx
+++ b/templates/alloy/src/components/News.tsx
@@ -92,8 +92,8 @@ function News({ content }: NewsPageProps) {
 
           {/* Teasers - Full Width */}
           <div {...pa('teasers')} className='lg:col-span-2 w-full space-y-4'>
-            {content.teasers?.map((teaser, index) => (
-              <OptimizelyComponent key={index} content={teaser} tag='teaser' />
+            {content.teasers?.map(teaser => (
+              <OptimizelyComponent key={teaser._opuid} content={teaser} tag='teaser' />
             ))}
           </div>
         </div>

--- a/templates/alloy/src/components/Product.tsx
+++ b/templates/alloy/src/components/Product.tsx
@@ -91,8 +91,8 @@ function Product({ content }: ProductProps) {
 
           {/* Sidebar */}
           <div {...pa('content_area')} className='space-y-6 sm:space-y-8'>
-            {content.content_area?.map((contentItem, index) => {
-              return <OptimizelyComponent key={index} content={contentItem} />;
+            {content.content_area?.map(contentItem => {
+              return <OptimizelyComponent key={contentItem._opuid} content={contentItem} />;
             })}
           </div>
           <div className='flex flex-col space-y-6 sm:space-y-8'>

--- a/templates/alloy/src/components/base/NewsEventsList.tsx
+++ b/templates/alloy/src/components/base/NewsEventsList.tsx
@@ -52,8 +52,8 @@ function NewsEventsList({ content }: NewsEventsListProps) {
 
       {/* Teasers List */}
       <div className='space-y-6' {...pa('teasers')}>
-        {content.teasers?.map((teaser, index) => {
-          return <OptimizelyComponent key={index} content={teaser} tag='teaser' />;
+        {content.teasers?.map(teaser => {
+          return <OptimizelyComponent key={teaser._opuid} content={teaser} tag='teaser' />;
         })}
       </div>
 


### PR DESCRIPTION
- Introduce a SDK generated  unique ID called `_opuid` for inline content with array items and content reference (for content with `_metadata.key` is present, it will be assigned to `_opuid` ).