### PR TITLE
CMS-55015 Introduce configurable composition depth for experience fragments

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/constants.ts
+++ b/packages/optimizely-cms-sdk/src/graph/constants.ts
@@ -24,3 +24,9 @@ export const DEFAULT_MAX_FRAGMENT_THRESHOLD = 100;
  * When false, only the contract itself is included without expansion.
  */
 export const DEFAULT_EXPAND_CONTRACTS = false;
+
+/**
+ * Default nesting depth for ordinary experience compositions.
+ * Configurable via `config({ compositionDepth })`.
+ */
+export const DEFAULT_COMPOSITION_DEPTH = 4;

--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -108,7 +108,7 @@ const createExperienceFragments = (
   const experienceResult = buildFragmentsForKeys(experienceNodeKeys, visited, ctx);
   return {
     fragments: [
-      ...getFixedFragments(ctx.formsEnabled, includeExperienceFragment),
+      ...getFixedFragments(ctx.formsEnabled, includeExperienceFragment, ctx.compositionDepth),
       ...experienceResult.fragments,
       buildInterfaceFragment('_IComponent', experienceNodeKeys),
     ],

--- a/packages/optimizely-cms-sdk/src/graph/index.ts
+++ b/packages/optimizely-cms-sdk/src/graph/index.ts
@@ -41,6 +41,7 @@ import {
   DEFAULT_USER_AGENT,
   DEFAULT_MAX_FRAGMENT_THRESHOLD,
   DEFAULT_EXPAND_CONTRACTS,
+  DEFAULT_COMPOSITION_DEPTH,
   GRAPH_PATH,
 } from './constants.js';
 
@@ -54,6 +55,15 @@ export type GraphOptions = {
   host?: string;
   /** Hard limit on generated fragments per content area. Throws GraphFragmentThresholdError when exceeded on unconstrained properties. */
   maxFragmentThreshold?: number;
+  /**
+   * Nesting depth for ordinary composition fragments (sections/rows/columns/elements
+   * inside an experience). Raise it if a composition is nested deeper than the default.
+   *
+   * Temporary: only needed because Graph's `@recursive` directive doesn't retrieve
+   * DAM assets. Once it does, fragments recurse to any depth and this setting goes away.
+   * @default 4
+   */
+  compositionDepth?: number;
   /**
    * Enable or disable contract expansion.
    * When true, contracts are expanded to include all implementing types.
@@ -210,10 +220,18 @@ const METADATA_OP_NAMES: Record<FilterShape, string> = {
   'by-path': 'GetContentMetadataByPath',
 };
 
-function getMetadataQuery(shape: FilterShape, variationMode: VariationMode = 'none'): string {
+function getMetadataQuery(
+  shape: FilterShape,
+  variationMode: VariationMode = 'none',
+): string {
   const varDecls = getFilterVarDecls(shape);
   const variationVars = getVariationVarDecls(variationMode);
-  const allVars = [varDecls, variationVars, '$formsWhere: _ExperienceWhereInput', '$withForms: Boolean!']
+  const allVars = [
+    varDecls,
+    variationVars,
+    '$formsWhere: _ExperienceWhereInput',
+    '$withForms: Boolean!',
+  ]
     .filter(Boolean)
     .join(', ');
   const whereClause = getFilterWhereClause(shape);
@@ -332,10 +350,7 @@ const LINKS_BODY = (linkType: 'PATH' | 'ITEMS') => `{
     }
   }`;
 
-function getLinksQuery(
-  opName: string,
-  shape: FilterShape,
-): string {
+function getLinksQuery(opName: string, shape: FilterShape): string {
   const filterVars = getFilterVarDecls(shape);
   const whereClause = getFilterWhereClause(shape);
   const allVars = [filterVars, '$locale: [Locales]'].sort().join(', ');
@@ -345,10 +360,7 @@ query ${opName}(${allVars}) {
 }`;
 }
 
-function getItemsQuery(
-  opName: string,
-  shape: FilterShape,
-): string {
+function getItemsQuery(opName: string, shape: FilterShape): string {
   const filterVars = getFilterVarDecls(shape);
   const whereClause = getFilterWhereClause(shape);
   const allVars = [filterVars, '$locale: [Locales]'].sort().join(', ');
@@ -357,7 +369,6 @@ query ${opName}(${allVars}) {
   _Content(${whereClause}, locale: $locale) ${LINKS_BODY('ITEMS')}
 }`;
 }
-
 
 type GetLinksResponse = {
   _Content: {
@@ -534,6 +545,7 @@ export class GraphClient {
   apiKey: string;
   graphUrl: string;
   maxFragmentThreshold: number;
+  compositionDepth: number;
   expandContracts: boolean;
   host?: string;
   cache: boolean;
@@ -548,6 +560,7 @@ export class GraphClient {
     this.graphUrl = normalizeGraphUrl(options.graphUrl || DEFAULT_GRAPH_URL);
     this.maxFragmentThreshold =
       options.maxFragmentThreshold ?? DEFAULT_MAX_FRAGMENT_THRESHOLD;
+    this.compositionDepth = options.compositionDepth ?? DEFAULT_COMPOSITION_DEPTH;
     this.expandContracts = options.expandContracts ?? DEFAULT_EXPAND_CONTRACTS;
     this.host = options.host;
     this.cache = options.cache ?? true;
@@ -746,6 +759,7 @@ export class GraphClient {
         const query = createSingleContentQuery(FORM_CONTAINER_TYPE, {
           damEnabled: options.damEnabled,
           maxFragmentThreshold: this.maxFragmentThreshold,
+          compositionDepth: this.compositionDepth,
           expandContracts: this.expandContracts,
           formsEnabled: true,
           sectionTypes: options.sectionTypes,
@@ -902,6 +916,7 @@ export class GraphClient {
         const query = createMultipleContentQuery(contentTypeName, {
           damEnabled,
           maxFragmentThreshold: this.maxFragmentThreshold,
+          compositionDepth: this.compositionDepth,
           expandContracts: this.expandContracts,
           formsEnabled,
           sectionTypes,
@@ -1100,7 +1115,12 @@ export class GraphClient {
       if (!contentTypeName) {
         throw new GraphResponseError(
           `Content with key '${params.key}' could not be found. Verify it exists in the CMS.`,
-          { request: { variables: filter.variables, query: getMetadataQuery(filter.filterShape, 'all') } },
+          {
+            request: {
+              variables: filter.variables,
+              query: getMetadataQuery(filter.filterShape, 'all'),
+            },
+          },
         );
       }
 
@@ -1118,6 +1138,7 @@ export class GraphClient {
       const query = createSingleContentQuery(contentTypeName, {
         damEnabled,
         maxFragmentThreshold: this.maxFragmentThreshold,
+        compositionDepth: this.compositionDepth,
         expandContracts: this.expandContracts,
         formsEnabled,
         sectionTypes,
@@ -1289,6 +1310,7 @@ export class GraphClient {
         const query = createSingleContentQuery(contentTypeName, {
           damEnabled,
           maxFragmentThreshold: this.maxFragmentThreshold,
+          compositionDepth: this.compositionDepth,
           expandContracts: this.expandContracts,
           formsEnabled,
           sectionTypes,

--- a/packages/optimizely-cms-sdk/src/util/baseTypeUtil.ts
+++ b/packages/optimizely-cms-sdk/src/util/baseTypeUtil.ts
@@ -5,6 +5,7 @@ import {
   PermittedTypes,
   MediaStringTypes,
 } from '../model/contentTypes.js';
+import { DEFAULT_COMPOSITION_DEPTH } from '../graph/constants.js';
 
 export type BaseTypeFragments = {
   fields: string[];
@@ -67,8 +68,9 @@ export const stripSourcePrefix = (key: string): string => key.replace(/^[a-z]+:/
  * @param depth - Current nesting level (0 = deepest).
  * @returns Nested fragment string.
  *
- * NOTE: Temporary workaround for Graph issue with @recursive directive.
- * This function will not be used once Graph properly supports @recursive.
+ * NOTE: Temporary workaround for a Graph issue — the `@recursive` directive
+ * doesn't retrieve DAM assets. This function will not be used once Graph
+ * fixes that.
  */
 function buildNestedCompositionNodes(depth: number): string {
   const baseFields =
@@ -81,9 +83,6 @@ function buildNestedCompositionNodes(depth: number): string {
   const nested = buildNestedCompositionNodes(depth - 1);
   return `${baseFields} ...on CompositionStructureNode { component { ..._IComponent } nodes { ${nested} ...on CompositionComponentNode { nodeType component { ..._IComponent } } } } ...on CompositionComponentNode { nodeType component { ..._IComponent } }`;
 }
-
-/** Nesting depth that covers ordinary experience compositions. */
-const COMPOSITION_NESTING_DEPTH = 4;
 
 /**
  * Forms nest deeper than an ordinary composition — steps hold rows, which hold
@@ -111,18 +110,21 @@ export const DAM_ASSET_FRAGMENTS = [
  * @param includeExperienceFragment Emit `_IExperience` too. A section reads its
  *   `composition` field directly rather than spreading that fragment, and
  *   GraphQL rejects a document containing a fragment nothing uses.
+ * @param compositionDepth Nesting depth for ordinary compositions. Ignored when
+ *   `formsEnabled`, which always needs the deeper Forms depth.
  */
 export const getFixedFragments = (
   formsEnabled = false,
   includeExperienceFragment = true,
+  compositionDepth = DEFAULT_COMPOSITION_DEPTH,
 ) => [
   ...(includeExperienceFragment ?
     ['fragment _IExperience on _IExperience { composition {...ICompositionNode }}']
   : []),
-  // This is a temporary workaround for Graph issue with @recursive directive. This will not be used once Graph properly supports @recursive.
-  // Replace it with a simpler recursive fragment once Graph supports @recursive, e.g. 'fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }':
+  // Temporary workaround: Graph's @recursive directive doesn't retrieve DAM assets.
+  // Replace it with a simpler recursive fragment once Graph fixes that, e.g. 'fragment ICompositionNode on ICompositionNode { __typename key type nodeType layoutType displayName displayTemplateKey displaySettings {key value} ...on CompositionStructureNode { nodes @recursive } ...on CompositionComponentNode { nodeType component { ..._IComponent } } }':
   `fragment ICompositionNode on ICompositionNode { ${buildNestedCompositionNodes(
-    formsEnabled ? FORMS_COMPOSITION_NESTING_DEPTH : COMPOSITION_NESTING_DEPTH,
+    formsEnabled ? FORMS_COMPOSITION_NESTING_DEPTH : compositionDepth,
   )} }`,
 ];
 

--- a/packages/optimizely-cms-sdk/src/util/queryUtils.ts
+++ b/packages/optimizely-cms-sdk/src/util/queryUtils.ts
@@ -24,6 +24,7 @@ import { isFormContentType } from '../model/formContentTypes.js';
 import {
   DEFAULT_MAX_FRAGMENT_THRESHOLD,
   DEFAULT_EXPAND_CONTRACTS,
+  DEFAULT_COMPOSITION_DEPTH,
 } from '../graph/constants.js';
 
 const getImplementedContracts = (contentType: AnyContentType): RegistryEntry[] => {
@@ -101,6 +102,11 @@ export type QueryContext = {
    */
   formsEnabled: boolean;
   /**
+   * Nesting depth for ordinary composition fragments. Configurable via
+   * `config({ compositionDepth })`.
+   */
+  compositionDepth: number;
+  /**
    * Optional filter to exclude content types from fragment generation.
    * Return true to include a content type, false to exclude it.
    * Useful for skipping content types that have no registered component.
@@ -161,6 +167,7 @@ export const createQueryContext = (
   maxFragmentThreshold: options.maxFragmentThreshold ?? DEFAULT_MAX_FRAGMENT_THRESHOLD,
   expandContracts: options.expandContracts ?? DEFAULT_EXPAND_CONTRACTS,
   formsEnabled: options.formsEnabled ?? false,
+  compositionDepth: options.compositionDepth ?? DEFAULT_COMPOSITION_DEPTH,
   typeFilter: options.typeFilter,
   sectionTypes: options.sectionTypes,
   ancestors: options.ancestors ?? new Set(),


### PR DESCRIPTION
- Introduce a user defined attribute to define composition fragment depth. Since `@recursive` directive in doesn't retrieve DAM assets.

Note: This is still a temporary fix and this attribute will be removed or once the issues with `@recursive` directive and DAM assets is fixed