### PR TITLE
CMS-55749 Fix component glob exclusions and precedence; add tests for nested file exclusion and pattern order

### DIFF
--- a/.changeset/modern-wasps-carry.md
+++ b/.changeset/modern-wasps-carry.md
@@ -1,0 +1,6 @@
+---
+'@optimizely/cms-cli': patch
+---
+
+Fix components glob exclusions and precedence: !dir now excludes nested files, and pattern
+order determines which content type wins on key conflicts

--- a/packages/optimizely-cms-cli/src/service/utils.ts
+++ b/packages/optimizely-cms-cli/src/service/utils.ts
@@ -125,11 +125,24 @@ const compileAndImport = async (inputName: string, cwdUrl: string, outDir: strin
   }
 };
 
+/**
+ * Splits `components` config entries into glob include patterns and exclude patterns.
+ * Entries starting with `!` (e.g. `!src/legacy`) are treated as exclusions and are
+ * fed to `glob`'s `ignore` option instead of being globbed themselves.
+ */
 const separatePatterns = (paths: string[]): { include: string[]; exclude: string[] } => {
+  // keep everything that is NOT an exclusion (`!`-prefixed) as an include pattern
   const include = paths.filter(path => !path.startsWith('!'));
+
   const exclude = paths
+    // pick out only the exclusion entries
     .filter(path => path.startsWith('!'))
-    .map(path => path.substring(1));
+    // drop the leading '!' so it becomes a plain glob pattern
+    .map(path => path.substring(1))
+    // expand each pattern to also match files nested under it, so a bare
+    // directory exclude like `!src/legacy` also excludes `src/legacy/Old.ts`
+    .flatMap(path => [path, `${path}/**`]);
+
   return { include, exclude };
 };
 
@@ -158,7 +171,8 @@ const findFilesFromPatterns = async (
     )
   ).flat();
 
-  return unique(allFilesWithDuplicates).sort();
+  // preserve `components` pattern order so earlier entries take precedence on key conflicts
+  return unique(allFilesWithDuplicates);
 };
 
 const printFileContent = (

--- a/packages/optimizely-cms-cli/src/tests/findMetaData.test.ts
+++ b/packages/optimizely-cms-cli/src/tests/findMetaData.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { findMetaData } from '../service/utils.js';
+
+const contentTypeSource = (key: string, displayName = key) =>
+  `export const ${key} = { __type: 'contentType', key: '${key}', displayName: '${displayName}', baseType: 'component', properties: {} };\n`;
+
+describe('findMetaData', () => {
+  it('excludes files nested under a bare directory pattern (e.g. "!src/legacy")', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'cli-filter-test-'));
+
+    try {
+      await mkdir(join(tempDir, 'comp', 'legacy'), { recursive: true });
+      await writeFile(join(tempDir, 'comp', 'Hero.ts'), contentTypeSource('Hero'));
+      // invalid syntax: if this file is not excluded, esbuild throws and the test fails
+      await writeFile(join(tempDir, 'comp', 'legacy', 'Old.ts'), 'not valid ts !!! (((');
+
+      const cwd = pathToFileURL(`${tempDir}/`).href;
+      const { contentTypes } = await findMetaData(
+        ['comp/**/*.ts', '!comp/legacy'],
+        cwd,
+      );
+
+      expect(contentTypes.map(c => c.key)).toEqual(['Hero']);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves `components` pattern order so earlier entries take precedence on key conflicts', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'cli-order-test-'));
+
+    try {
+      await mkdir(join(tempDir, 'src', 'app', 'components'), { recursive: true });
+      await mkdir(join(tempDir, 'node_modules', 'my-package'), { recursive: true });
+      await writeFile(
+        join(tempDir, 'src', 'app', 'components', 'Hero.ts'),
+        contentTypeSource('Hero', 'Custom Hero'),
+      );
+      await writeFile(
+        join(tempDir, 'node_modules', 'my-package', 'Hero.ts'),
+        contentTypeSource('Hero', 'Package Hero'),
+      );
+
+      const cwd = pathToFileURL(`${tempDir}/`).href;
+      // custom implementation listed first, package default listed second
+      const { contentTypes } = await findMetaData(
+        ['src/app/**/components/**/*.ts', 'node_modules/my-package/**/*.ts'],
+        cwd,
+      );
+
+      // first match in `components` order must come first in the result
+      expect(contentTypes.map(c => c.displayName)).toEqual(['Custom Hero', 'Package Hero']);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
- Fix components glob exclusions and precedence: !dir now excludes nested files, and pattern order determines which content type wins on key conflicts