### PR TITLE
CMS-55716 Fix composition field queried on non-section types in root-call

### DIFF
--- a/packages/optimizely-cms-sdk/src/graph/createQuery.ts
+++ b/packages/optimizely-cms-sdk/src/graph/createQuery.ts
@@ -302,10 +302,9 @@ export const createFragment = (
     // must be known to exist; use caller's schema list if available,
     // otherwise fall back to the forms container.
     const canBeAsked =
-      isRootCall ||
       (ctx.sectionTypes ?
         ctx.sectionTypes.has(stripSourcePrefix(contentTypeName))
-      : isFormContentType(contentTypeName));
+      : isRootCall || isFormContentType(contentTypeName));
     const isStandaloneSection =
       canBeAsked && !insideComposition && !isExperience && holdsComposition(contentType);
 


### PR DESCRIPTION
When sectionTypes is available, prioritize schema check over isRootCall to prevent querying composition on types that don't implement _ISection.

CMS-55716