### PR TITLE
[Stride] Form section is not align with other section

### DIFF
--- a/templates/stride/components/forms/FormContainer.tsx
+++ b/templates/stride/components/forms/FormContainer.tsx
@@ -57,7 +57,7 @@ export default function FormContainer({ content }: FormContainerProps) {
   return (
     <FormSubmissionProvider>
       {/* Forms read better narrow. Long lines make a field look like a text block. */}
-      <div id='form-alert' className='max-w-2xl space-y-5'>
+      <div id='form-alert' className='container mx-auto space-y-5'>
         <div className='space-y-2'>
           {/* `h2`, not `h1` — the form is a block on a page that already has a heading. */}
           {content.Title && (


### PR DESCRIPTION

<img width="1259" height="871" alt="image" src="https://github.com/user-attachments/assets/0c3bacde-296a-4af9-a1e6-1383c29fb506" />

Bug: CMS-55723