### PR TITLE
CMS-44227 integration testing setup

### DIFF
--- a/.env.integration.template
+++ b/.env.integration.template
@@ -1,0 +1,11 @@
+# GraphQL Integration Tests (SDK)
+OPTIMIZELY_GRAPH_SINGLE_KEY=your_api_key_here
+OPTIMIZELY_GRAPH_GATEWAY=https://cg.optimizely.com/content/v2
+
+# REST API Integration Tests (CLI)
+OPTIMIZELY_CMS_CLIENT_ID=your_client_id_here
+OPTIMIZELY_CMS_CLIENT_SECRET=your_client_secret_here
+OPTIMIZELY_CMS_API_URL=https://api.cms.optimizely.com
+
+# Test Configuration
+INTEGRATION_TEST_SKIP_CLEANUP=false

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ dist
 .vscode
 .tanstack
 
+# Generated JS from TS scripts
+**/*.js
+!node_modules/**/*.js
+
 # Auto-generated files
 packages/optimizely-cms-sdk/src/generated/
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ jspm_packages/
 .env.test.local
 .env.production.local
 .env.local
+.env.integration
 
 
 dist

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,7 +53,7 @@ cp .env.integration.template .env.integration
 
 # 3. (Optional) Clean up leftover test data from previous runs
 cd packages/optimizely-cms-cli
-pnpm cleanup-test-types
+pnpm test:cleanup
 
 # 4. Run integration tests
 cd packages/optimizely-cms-sdk

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,6 +34,43 @@ You can also pass the `--help` flag to any command to see the flags and argument
 
 - For `nextjs-template`, read the [README.md file in that project](./samples/nextjs-template/README.md)
 
+## Integration Testing
+
+This repository includes integration tests that can validate the SDK against a real Optimizely CMS instance.
+
+### Test Coverage
+
+- **optimizely-cms-sdk** - Content fetching using Graph API
+- **optimizely-cms-cli** - Content type operations using the API
+
+### Quick Setup
+
+```bash
+# 1. Copy environment template
+cp .env.integration.template .env.integration
+
+# 2. Add your test CMS credentials in .env.integration
+
+# 3. (Optional) Clean up leftover test data from previous runs
+cd packages/optimizely-cms-cli
+pnpm cleanup-test-types
+
+# 4. Run integration tests
+cd packages/optimizely-cms-sdk
+pnpm test:integration
+
+cd ../optimizely-cms-cli
+pnpm test:integration
+```
+
+### Details
+
+- Tests require a dedicated test CMS instance
+- GraphQL tests validate real content queries against Content Graph API
+- REST API tests create and clean up test content types automatically with `TEST_` prefix
+- Set `INTEGRATION_TEST_SKIP_CLEANUP=true` environment variable to debug test data
+- See [INTEGRATION_TESTS.md](./INTEGRATION_TESTS.md) for comprehensive setup and troubleshooting guide
+
 ## Versioning and release workflow
 
 This project uses [Changesets](https://github.com/changesets/changesets) for version management and releases.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "install:all": "pnpm --filter \"./packages/**\" install && pnpm --filter \"./packages/**\" build && pnpm --filter \"./samples/**\" --filter \"./templates/**\" install",
     "build:samples": "pnpm --filter \"./samples/**\" build",
     "clean:all": "pnpm -r clean",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "pnpm --filter \"./packages/**\" test",
     "publish:all": "pnpm --filter \"./packages/**\" publish --access public --no-git-checks",
     "update-hooks": "pnpm simple-git-hooks"
   },

--- a/packages/optimizely-cms-cli/package.json
+++ b/packages/optimizely-cms-cli/package.json
@@ -13,8 +13,10 @@
     "build": "tsc",
     "clean": "rimraf dist",
     "test": "vitest --typecheck",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "debug": "node --inspect-brk ./bin/run.js",
-    "update:schema": "node ./scripts/generate-schema.js"
+    "update:schema": "node ./scripts/generate-schema.js",
+    "test:cleanup": "tsx scripts/cleanup-test-types.ts"
   },
   "files": [
     "dist"

--- a/packages/optimizely-cms-cli/scripts/cleanup-test-types.ts
+++ b/packages/optimizely-cms-cli/scripts/cleanup-test-types.ts
@@ -1,0 +1,110 @@
+/**
+ * Cleanup script to delete all integration test content types (TEST_* prefix)
+ * Run before integration tests to ensure clean state
+ *
+ * Usage: npx tsx scripts/cleanup-test-types.ts
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { createRestApiClient } from '../src/service/cmsRestClient.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// .env.integration is in the project root, not in packages subdirectory
+const envPath = resolve(__dirname, '../../../.env.integration');
+
+// Load environment variables
+if (!existsSync(envPath)) {
+  console.error('❌ .env.integration not found');
+  console.error('Please create it by running: cp .env.integration.template .env.integration');
+  process.exit(1);
+}
+
+const envContent = readFileSync(envPath, 'utf-8');
+envContent.split('\n').forEach(line => {
+  const trimmed = line.trim();
+  if (trimmed && !trimmed.startsWith('#')) {
+    const [key, ...valueParts] = trimmed.split('=');
+    const value = valueParts.join('=');
+    if (key && value) {
+      process.env[key.trim()] = value.trim();
+    }
+  }
+});
+
+const clientId = process.env.OPTIMIZELY_CMS_CLIENT_ID;
+const clientSecret = process.env.OPTIMIZELY_CMS_CLIENT_SECRET;
+
+if (!clientId || !clientSecret) {
+  console.error('❌ Missing CMS credentials in .env.integration');
+  process.exit(1);
+}
+
+async function cleanup() {
+  try {
+    const client = await createRestApiClient({
+      clientId: clientId as string,
+      clientSecret: clientSecret as string,
+    });
+
+    // Delete content types with TEST_ prefix
+    console.log('\nFetching content types...');
+    const { data: typeData, error: typeError } = await client.GET('/contenttypes');
+
+    if (typeError) {
+      console.error('❌ Failed to fetch content types:', typeError);
+      process.exit(1);
+    }
+
+    if (!typeData || !typeData.items) {
+      console.error('❌ Unexpected response:', typeData);
+      process.exit(1);
+    }
+
+    console.log(`Found ${typeData.items.length} total content types`);
+
+    const testTypes = typeData.items.filter((ct: any) => ct.key.startsWith('TEST_'));
+
+    if (testTypes.length === 0) {
+      console.log('✅ No test content types to clean up');
+      process.exit(0);
+    }
+
+    console.log(`\n🧹 Found ${testTypes.length} test content types to delete:\n`);
+
+    let deleted = 0;
+    let failed = 0;
+
+    for (const type of testTypes) {
+      try {
+        console.log(`  Deleting ${type.key}...`);
+        const result = await (client.DELETE as any)('/contenttypes/{key}', {
+          params: { path: { key: type.key as string } },
+        });
+
+        if (result.error) {
+          console.error(`  ❌ Failed to delete ${type.key}:`, JSON.stringify(result.error, null, 2));
+          failed++;
+        } else {
+          deleted++;
+        }
+      } catch (err: any) {
+        console.error(`  ❌ Failed to delete ${type.key}: ${err?.message || err}`);
+        failed++;
+      }
+    }
+
+    console.log(`\n✅ Cleanup complete: ${deleted} content types deleted, ${failed} failed`);
+
+    if (failed > 0) {
+      console.warn('⚠️  Some content types could not be deleted');
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error('❌ Cleanup failed:', err);
+    process.exit(1);
+  }
+}
+
+cleanup();

--- a/packages/optimizely-cms-cli/scripts/cleanup-test-types.ts
+++ b/packages/optimizely-cms-cli/scripts/cleanup-test-types.ts
@@ -5,33 +5,15 @@
  * Usage: npx tsx scripts/cleanup-test-types.ts
  */
 
-import { readFileSync, existsSync } from 'fs';
-import { dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
 import { createRestApiClient } from '../src/service/cmsRestClient.js';
+import { loadEnvIntegration } from '../src/utils/loadEnvIntegration.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-// .env.integration is in the project root, not in packages subdirectory
-const envPath = resolve(__dirname, '../../../.env.integration');
+declare const process: {
+  env: Record<string, string | undefined>;
+  exit(code: number): never;
+};
 
-// Load environment variables
-if (!existsSync(envPath)) {
-  console.error('❌ .env.integration not found');
-  console.error('Please create it by running: cp .env.integration.template .env.integration');
-  process.exit(1);
-}
-
-const envContent = readFileSync(envPath, 'utf-8');
-envContent.split('\n').forEach(line => {
-  const trimmed = line.trim();
-  if (trimmed && !trimmed.startsWith('#')) {
-    const [key, ...valueParts] = trimmed.split('=');
-    const value = valueParts.join('=');
-    if (key && value) {
-      process.env[key.trim()] = value.trim();
-    }
-  }
-});
+loadEnvIntegration();
 
 const clientId = process.env.OPTIMIZELY_CMS_CLIENT_ID;
 const clientSecret = process.env.OPTIMIZELY_CMS_CLIENT_SECRET;
@@ -50,7 +32,9 @@ async function cleanup() {
 
     // Delete content types with TEST_ prefix
     console.log('\nFetching content types...');
-    const { data: typeData, error: typeError } = await client.GET('/contenttypes');
+    const response = await client.GET('/contenttypes');
+    const typeData = response.data as any;
+    const typeError = response.error as any;
 
     if (typeError) {
       console.error('❌ Failed to fetch content types:', typeError);
@@ -64,7 +48,7 @@ async function cleanup() {
 
     console.log(`Found ${typeData.items.length} total content types`);
 
-    const testTypes = typeData.items.filter((ct: any) => ct.key.startsWith('TEST_'));
+    const testTypes = (typeData.items as any[]).filter((ct: any) => ct.key.startsWith('TEST_'));
 
     if (testTypes.length === 0) {
       console.log('✅ No test content types to clean up');
@@ -73,27 +57,18 @@ async function cleanup() {
 
     console.log(`\n🧹 Found ${testTypes.length} test content types to delete:\n`);
 
-    let deleted = 0;
-    let failed = 0;
+    testTypes.forEach(ct => console.log(`  ${ct.key}`));
 
-    for (const type of testTypes) {
-      try {
-        console.log(`  Deleting ${type.key}...`);
-        const result = await (client.DELETE as any)('/contenttypes/{key}', {
+    const results = await Promise.allSettled(
+      testTypes.map(type =>
+        (client.DELETE as any)('/contenttypes/{key}', {
           params: { path: { key: type.key as string } },
-        });
+        })
+      )
+    );
 
-        if (result.error) {
-          console.error(`  ❌ Failed to delete ${type.key}:`, JSON.stringify(result.error, null, 2));
-          failed++;
-        } else {
-          deleted++;
-        }
-      } catch (err: any) {
-        console.error(`  ❌ Failed to delete ${type.key}: ${err?.message || err}`);
-        failed++;
-      }
-    }
+    const deleted = results.filter(r => r.status === 'fulfilled' && !r.value?.error).length;
+    const failed = results.length - deleted;
 
     console.log(`\n✅ Cleanup complete: ${deleted} content types deleted, ${failed} failed`);
 

--- a/packages/optimizely-cms-cli/src/__integration__/content-types.integration.test.ts
+++ b/packages/optimizely-cms-cli/src/__integration__/content-types.integration.test.ts
@@ -59,28 +59,40 @@ describe('Content Type CRUD Operations', () => {
       const typeKey = getUniqueTypeKey('CreatePage');
       createdTypes.push(typeKey);
 
-      const { data, error } = await client.POST('/contenttypes', {
+      const createResponse = await client.POST('/contenttypes', {
         body: createMinimalPageType(typeKey),
       });
 
-      expect(error).toBeUndefined();
-      expect(data).toBeDefined();
-      expect(data.key).toBe(typeKey);
-      expect(data.baseType).toBe('_page');
+      expect(createResponse.response?.status).toBe(201);
+
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      const { data: fetchedType } = await client.GET('/contenttypes/{key}', {
+        params: { path: { key: typeKey } },
+      });
+
+      expect(fetchedType).toBeDefined();
+      expect(fetchedType.key).toBe(typeKey);
+      expect(fetchedType.baseType).toBe('_page');
     });
 
     test('should create component type', async () => {
       const typeKey = getUniqueTypeKey('CreateComponent');
       createdTypes.push(typeKey);
 
-      const { data, error } = await client.POST('/contenttypes', {
+      const createResponse = await client.POST('/contenttypes', {
         body: createMinimalComponentType(typeKey),
       });
 
-      expect(error).toBeUndefined();
-      expect(data).toBeDefined();
-      expect(data.key).toBe(typeKey);
-      expect(data.baseType).toBe('_component');
+      expect(createResponse.response?.status).toBe(201);
+
+      const { data: fetchedType } = await client.GET('/contenttypes/{key}', {
+        params: { path: { key: typeKey } },
+      });
+
+      expect(fetchedType).toBeDefined();
+      expect(fetchedType.key).toBe(typeKey);
+      expect(fetchedType.baseType).toBe('_component');
     });
   });
 
@@ -93,8 +105,7 @@ describe('Content Type CRUD Operations', () => {
         body: createMinimalPageType(typeKey),
       });
 
-      expect(createResponse.error).toBeUndefined();
-      expect(createResponse.data).toBeDefined();
+      expect(createResponse.response?.status).toBe(201);
 
       const { data, error } = await client.GET('/contenttypes/{key}', {
         params: { path: { key: typeKey } },

--- a/packages/optimizely-cms-cli/src/__integration__/content-types.integration.test.ts
+++ b/packages/optimizely-cms-cli/src/__integration__/content-types.integration.test.ts
@@ -1,0 +1,149 @@
+import './setup.js';
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import {
+  createTestRestClient,
+  generateTestPrefix,
+  cleanupTestContentTypes,
+  skipCleanup,
+} from './helpers.js';
+import { createMinimalPageType, createMinimalComponentType } from './fixtures.js';
+
+describe('Content Type CRUD Operations', () => {
+  // Note: These tests will fail if REST API credentials are not set in .env.integration
+  // See error messages at test startup for setup instructions
+  let client: any;
+  let testPrefix: string;
+  const createdTypes: string[] = [];
+  let counter = 0;
+
+  const getUniqueTypeKey = (baseName: string) => `${testPrefix}${baseName}_${++counter}`;
+
+  beforeAll(async () => {
+    client = await createTestRestClient();
+    testPrefix = generateTestPrefix();
+  });
+
+  afterAll(async () => {
+    if (client && !skipCleanup()) {
+      await cleanupTestContentTypes(client, testPrefix);
+    }
+  });
+
+  describe('GET /contenttypes', () => {
+    test('should list all content types', async () => {
+      const { data, error } = await client.GET('/contenttypes');
+
+      expect(error).toBeUndefined();
+      expect(data).toBeDefined();
+      expect(Array.isArray(data.items)).toBe(true);
+      expect(data.items.length).toBeGreaterThan(0);
+    });
+
+    test('should include base content types', async () => {
+      const { data } = await client.GET('/contenttypes');
+
+      const hasPageType = data.items.some(
+        (ct: any) => ct.baseType === '_page'
+      );
+      const hasComponentType = data.items.some(
+        (ct: any) => ct.baseType === '_component'
+      );
+
+      expect(hasPageType).toBe(true);
+      expect(hasComponentType).toBe(true);
+    });
+  });
+
+  describe('POST /contenttypes', () => {
+    test('should create individual content type', async () => {
+      const typeKey = getUniqueTypeKey('CreatePage');
+      createdTypes.push(typeKey);
+
+      const { data, error } = await client.POST('/contenttypes', {
+        body: createMinimalPageType(typeKey),
+      });
+
+      expect(error).toBeUndefined();
+      expect(data).toBeDefined();
+      expect(data.key).toBe(typeKey);
+      expect(data.baseType).toBe('_page');
+    });
+
+    test('should create component type', async () => {
+      const typeKey = getUniqueTypeKey('CreateComponent');
+      createdTypes.push(typeKey);
+
+      const { data, error } = await client.POST('/contenttypes', {
+        body: createMinimalComponentType(typeKey),
+      });
+
+      expect(error).toBeUndefined();
+      expect(data).toBeDefined();
+      expect(data.key).toBe(typeKey);
+      expect(data.baseType).toBe('_component');
+    });
+  });
+
+  describe('GET /contenttypes/{key}', () => {
+    test('should fetch specific content type', async () => {
+      const typeKey = getUniqueTypeKey('FetchPage');
+      createdTypes.push(typeKey);
+
+      const createResponse = await client.POST('/contenttypes', {
+        body: createMinimalPageType(typeKey),
+      });
+
+      expect(createResponse.error).toBeUndefined();
+      expect(createResponse.data).toBeDefined();
+
+      const { data, error } = await client.GET('/contenttypes/{key}', {
+        params: { path: { key: typeKey } },
+      });
+
+      expect(error).toBeUndefined();
+      expect(data).toBeDefined();
+      expect(data.key).toBe(typeKey);
+      expect(data.properties).toBeDefined();
+    });
+
+    test('should return 404 for non-existent type', async () => {
+      const { error } = await client.GET('/contenttypes/{key}', {
+        params: { path: { key: getUniqueTypeKey('NonExistent') } },
+      });
+
+      expect(error).toBeDefined();
+      expect(error.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /contenttypes/{key}', () => {
+    test('should delete content type', async () => {
+      const typeKey = getUniqueTypeKey('DeletePage');
+
+      await client.POST('/contenttypes', {
+        body: createMinimalPageType(typeKey),
+      });
+
+      const { error: deleteError } = await client.DELETE(
+        '/contenttypes/{key}',
+        {
+          params: { path: { key: typeKey } },
+        }
+      );
+
+      expect(deleteError).toBeUndefined();
+
+      const { error: fetchError } = await client.GET(
+        '/contenttypes/{key}',
+        {
+          params: { path: { key: typeKey } },
+        }
+      );
+
+      expect(fetchError).toBeDefined();
+      expect(fetchError.status).toBe(404);
+
+      createdTypes.splice(createdTypes.indexOf(typeKey), 1);
+    });
+  });
+});

--- a/packages/optimizely-cms-cli/src/__integration__/fixtures.ts
+++ b/packages/optimizely-cms-cli/src/__integration__/fixtures.ts
@@ -1,0 +1,33 @@
+export const createMinimalPageType = (key: string) => ({
+  key,
+  baseType: '_page',
+  displayName: `Test Page ${key}`,
+  properties: {
+    heading: {
+      type: 'string',
+      displayName: 'Heading',
+      isRequired: true,
+    },
+    body: {
+      type: 'richText',
+      displayName: 'Body',
+    },
+  },
+});
+
+export const createMinimalComponentType = (key: string) => ({
+  key,
+  baseType: '_component',
+  displayName: `Test Component ${key}`,
+  properties: {
+    text: {
+      type: 'string',
+      displayName: 'Text',
+    },
+  },
+});
+
+export const createManifestPayload = (contentTypes: any[]) => ({
+  contentTypes,
+  displayTemplates: [],
+});

--- a/packages/optimizely-cms-cli/src/__integration__/helpers.ts
+++ b/packages/optimizely-cms-cli/src/__integration__/helpers.ts
@@ -1,0 +1,34 @@
+import { createRestApiClient } from '../service/cmsRestClient.js';
+
+export const createTestRestClient = () =>
+  createRestApiClient({
+    clientId: process.env.OPTIMIZELY_CMS_CLIENT_ID!,
+    clientSecret: process.env.OPTIMIZELY_CMS_CLIENT_SECRET!,
+  });
+
+export const generateTestPrefix = () =>
+  `TEST_${Date.now()}_${Math.random().toString(36).substring(2, 9)}_`;
+
+export const skipCleanup = () =>
+  process.env.INTEGRATION_TEST_SKIP_CLEANUP === 'true';
+
+export const cleanupTestContentTypes = async (
+  client: any,
+  prefix: string
+) => {
+  const { data } = await client.GET('/contenttypes');
+  const testTypes = (data?.items ?? []).filter(
+    (ct: any) =>
+      ct.key.startsWith(prefix) && ct.source === 'user'
+  );
+
+  for (const type of testTypes) {
+    try {
+      await client.DELETE('/contenttypes/{key}', {
+        params: { path: { key: type.key } },
+      });
+    } catch (err) {
+      console.warn(`Cleanup failed for ${type.key}:`, err);
+    }
+  }
+};

--- a/packages/optimizely-cms-cli/src/__integration__/helpers.ts
+++ b/packages/optimizely-cms-cli/src/__integration__/helpers.ts
@@ -18,17 +18,14 @@ export const cleanupTestContentTypes = async (
 ) => {
   const { data } = await client.GET('/contenttypes');
   const testTypes = (data?.items ?? []).filter(
-    (ct: any) =>
-      ct.key.startsWith(prefix) && ct.source === 'user'
+    (ct: any) => ct.key.startsWith(prefix)
   );
 
-  for (const type of testTypes) {
-    try {
-      await client.DELETE('/contenttypes/{key}', {
+  await Promise.allSettled(
+    testTypes.map((type: any) =>
+      client.DELETE('/contenttypes/{key}', {
         params: { path: { key: type.key } },
-      });
-    } catch (err) {
-      console.warn(`Cleanup failed for ${type.key}:`, err);
-    }
-  }
+      })
+    )
+  );
 };

--- a/packages/optimizely-cms-cli/src/__integration__/manifest-sync.integration.test.ts
+++ b/packages/optimizely-cms-cli/src/__integration__/manifest-sync.integration.test.ts
@@ -1,0 +1,116 @@
+import './setup.js';
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import {
+  createTestRestClient,
+  generateTestPrefix,
+  cleanupTestContentTypes,
+  skipCleanup,
+} from './helpers.js';
+import {
+  createMinimalPageType,
+  createMinimalComponentType,
+  createManifestPayload,
+} from './fixtures.js';
+
+describe('Manifest Sync', () => {
+  let client: any;
+  let testPrefix: string;
+  const createdTypes: string[] = [];
+
+  beforeAll(async () => {
+    client = await createTestRestClient();
+    testPrefix = generateTestPrefix();
+  });
+
+  afterAll(async () => {
+    if (client && !skipCleanup()) {
+      await cleanupTestContentTypes(client, testPrefix);
+    }
+  });
+
+  test('should upload new content type via manifest', async () => {
+    const typeKey = `${testPrefix}BlogPage`;
+    createdTypes.push(typeKey);
+
+    const { data, error } = await client.POST('/manifest', {
+      headers: {
+        'content-type':
+          'application/vnd.optimizely.cms.v1.manifest+json',
+      },
+      body: createManifestPayload([createMinimalPageType(typeKey)]),
+    });
+
+    expect(error).toBeUndefined();
+    expect(data).toBeDefined();
+    expect(data.outcomes).toBeDefined();
+  });
+
+  test('should fetch manifest', async () => {
+    const { data, error } = await client.GET('/manifest');
+
+    expect(error).toBeUndefined();
+    expect(data).toBeDefined();
+    expect(Array.isArray(data.contentTypes)).toBe(true);
+  });
+
+  test('should upload multiple content types in one manifest', async () => {
+    const pageKey = `${testPrefix}MultiPage`;
+    const componentKey = `${testPrefix}MultiComponent`;
+    createdTypes.push(pageKey, componentKey);
+
+    const { data, error } = await client.POST('/manifest', {
+      headers: {
+        'content-type':
+          'application/vnd.optimizely.cms.v1.manifest+json',
+      },
+      body: createManifestPayload([
+        createMinimalPageType(pageKey),
+        createMinimalComponentType(componentKey),
+      ]),
+    });
+
+    expect(error).toBeUndefined();
+    expect(data).toBeDefined();
+    expect(data.outcomes).toBeDefined();
+  });
+
+  test('should update existing content type in manifest', async () => {
+    const typeKey = `${testPrefix}UpdatePage`;
+    createdTypes.push(typeKey);
+
+    const initialType = createMinimalPageType(typeKey);
+
+    const uploadInitial = await client.POST('/manifest', {
+      headers: {
+        'content-type':
+          'application/vnd.optimizely.cms.v1.manifest+json',
+      },
+      body: createManifestPayload([initialType]),
+    });
+
+    expect(uploadInitial.error).toBeUndefined();
+
+    const updatedType = {
+      ...initialType,
+      displayName: 'Updated Test Page',
+      properties: {
+        ...initialType.properties,
+        subtitle: {
+          type: 'string',
+          displayName: 'Subtitle',
+        },
+      },
+    };
+
+    const uploadUpdated = await client.POST('/manifest', {
+      headers: {
+        'content-type':
+          'application/vnd.optimizely.cms.v1.manifest+json',
+      },
+      body: createManifestPayload([updatedType]),
+    });
+
+    expect(uploadUpdated.error).toBeUndefined();
+    expect(uploadUpdated.data).toBeDefined();
+  });
+});

--- a/packages/optimizely-cms-cli/src/__integration__/setup.ts
+++ b/packages/optimizely-cms-cli/src/__integration__/setup.ts
@@ -1,0 +1,46 @@
+import { readFileSync, existsSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(__dirname, '../../../../.env.integration');
+
+if (existsSync(envPath)) {
+  try {
+    const envFile = readFileSync(envPath, 'utf-8');
+    let count = 0;
+    envFile.split('\n').forEach(line => {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        const [key, ...valueParts] = trimmed.split('=');
+        const value = valueParts.join('=');
+        if (key && value) {
+          process.env[key.trim()] = value.trim();
+          count++;
+        }
+      }
+    });
+  } catch (err) {
+    console.warn('Failed to load .env.integration:', err);
+  }
+} else {
+  console.error(
+    '\n❌ Missing .env.integration file\n' +
+    '   REST API integration tests will be skipped.\n' +
+    '   To enable integration tests:\n' +
+    '   1. cp .env.integration.template .env.integration\n' +
+    '   2. Add your CMS credentials to .env.integration\n' +
+    '   See INTEGRATION_TESTS.md for details.\n'
+  );
+}
+
+const missingCreds: string[] = [];
+if (!process.env.OPTIMIZELY_CMS_CLIENT_ID) missingCreds.push('OPTIMIZELY_CMS_CLIENT_ID');
+if (!process.env.OPTIMIZELY_CMS_CLIENT_SECRET) missingCreds.push('OPTIMIZELY_CMS_CLIENT_SECRET');
+
+if (missingCreds.length > 0) {
+  console.error(
+    `❌ Missing credentials in .env.integration: ${missingCreds.join(', ')}\n` +
+    '   REST API integration tests will be skipped.\n'
+  );
+}

--- a/packages/optimizely-cms-cli/src/__integration__/setup.ts
+++ b/packages/optimizely-cms-cli/src/__integration__/setup.ts
@@ -1,38 +1,6 @@
-import { readFileSync, existsSync } from 'fs';
-import { dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { loadEnvIntegration } from '../utils/loadEnvIntegration.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const envPath = resolve(__dirname, '../../../../.env.integration');
-
-if (existsSync(envPath)) {
-  try {
-    const envFile = readFileSync(envPath, 'utf-8');
-    let count = 0;
-    envFile.split('\n').forEach(line => {
-      const trimmed = line.trim();
-      if (trimmed && !trimmed.startsWith('#')) {
-        const [key, ...valueParts] = trimmed.split('=');
-        const value = valueParts.join('=');
-        if (key && value) {
-          process.env[key.trim()] = value.trim();
-          count++;
-        }
-      }
-    });
-  } catch (err) {
-    console.warn('Failed to load .env.integration:', err);
-  }
-} else {
-  console.error(
-    '\n❌ Missing .env.integration file\n' +
-    '   REST API integration tests will be skipped.\n' +
-    '   To enable integration tests:\n' +
-    '   1. cp .env.integration.template .env.integration\n' +
-    '   2. Add your CMS credentials to .env.integration\n' +
-    '   See INTEGRATION_TESTS.md for details.\n'
-  );
-}
+loadEnvIntegration();
 
 const missingCreds: string[] = [];
 if (!process.env.OPTIMIZELY_CMS_CLIENT_ID) missingCreds.push('OPTIMIZELY_CMS_CLIENT_ID');

--- a/packages/optimizely-cms-cli/src/utils/loadEnvIntegration.ts
+++ b/packages/optimizely-cms-cli/src/utils/loadEnvIntegration.ts
@@ -1,0 +1,26 @@
+import { readFileSync, existsSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(__dirname, '../../../../.env.integration');
+
+export const loadEnvIntegration = (): void => {
+  if (!existsSync(envPath)) {
+    console.error('❌ .env.integration not found');
+    console.error('Please create it by running: cp .env.integration.template .env.integration');
+    process.exit(1);
+  }
+
+  const envContent = readFileSync(envPath, 'utf-8');
+  envContent.split('\n').forEach(line => {
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=');
+      const value = valueParts.join('=');
+      if (key && value) {
+        process.env[key.trim()] = value.trim();
+      }
+    }
+  });
+};

--- a/packages/optimizely-cms-cli/vitest.config.ts
+++ b/packages/optimizely-cms-cli/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/__tests__/**/*.ts'],
-    exclude: ['src/**/__integration__/**'],
+    exclude: ['node_modules/**', 'src/**/__integration__/**'],
     coverage: {
       reporter: ['text', 'html'],
     },

--- a/packages/optimizely-cms-cli/vitest.config.ts
+++ b/packages/optimizely-cms-cli/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/__tests__/**/*.ts'],
-    exclude: ['node_modules/**', 'src/**/__integration__/**'],
+    exclude: ['node_modules/**', 'dist/**', 'src/**/__integration__/**'],
     coverage: {
       reporter: ['text', 'html'],
     },

--- a/packages/optimizely-cms-cli/vitest.config.ts
+++ b/packages/optimizely-cms-cli/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/__tests__/**/*.ts'],
+    exclude: ['src/**/__integration__/**'],
     coverage: {
       reporter: ['text', 'html'],
     },

--- a/packages/optimizely-cms-cli/vitest.integration.config.ts
+++ b/packages/optimizely-cms-cli/vitest.integration.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/__integration__/**/*.integration.test.ts'],
+    setupFiles: ['src/__integration__/setup.ts'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    retry: 1,
+  },
+});

--- a/packages/optimizely-cms-sdk/package.json
+++ b/packages/optimizely-cms-sdk/package.json
@@ -67,7 +67,8 @@
     "prebuild": "node scripts/prebuild.js",
     "build": "tsc --project tsconfig.cjs.json && tsc --project tsconfig.esm.json",
     "clean": "rimraf dist",
-    "test": "vitest --typecheck"
+    "test": "vitest --typecheck",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "files": [
     "dist"

--- a/packages/optimizely-cms-sdk/src/graph/__integration__/content-fetching.integration.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__integration__/content-fetching.integration.test.ts
@@ -1,0 +1,64 @@
+import './setup.js';
+import { describe, test, expect, beforeAll } from 'vitest';
+import { GraphClient } from '../index.js';
+import { createTestGraphClient } from './helpers.js';
+
+describe('GraphQL Content Fetching', () => {
+  let client: GraphClient;
+
+  beforeAll(() => {
+    client = createTestGraphClient();
+  });
+
+  describe('getContentByPath', () => {
+    test('should handle path without trailing slash', async () => {
+      const results = await client.getContentByPath('/');
+      expect(results).toBeDefined();
+      expect(Array.isArray(results)).toBe(true);
+    });
+
+    test('should return empty array for non-existent path', async () => {
+      const results = await client.getContentByPath(
+        '/non-existent-path-xyz-12345/'
+      );
+      expect(results).toBeDefined();
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBe(0);
+    });
+
+    test('should return empty array for non-existent path without trailing slash', async () => {
+      const results = await client.getContentByPath(
+        '/non-existent-path-xyz-12345'
+      );
+      expect(results).toBeDefined();
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBe(0);
+    });
+  });
+
+  describe('getContent', () => {
+    test('should have GraphClient configured with API key', () => {
+      expect(client).toBeInstanceOf(GraphClient);
+      expect(client.graphUrl).toBeTruthy();
+    });
+
+    test('should support query options', async () => {
+      const results = await client.getContentByPath('/', {
+        cache: false,
+      });
+      expect(results).toBeDefined();
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    test('should not throw for missing content', async () => {
+      const results = await client.getContentByPath(
+        '/missing-content-xyz-12345/'
+      );
+      expect(results).toBeDefined();
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBe(0);
+    });
+  });
+});

--- a/packages/optimizely-cms-sdk/src/graph/__integration__/error-handling.integration.test.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__integration__/error-handling.integration.test.ts
@@ -1,0 +1,44 @@
+import './setup.js';
+import { describe, test, expect } from 'vitest';
+import { GraphClient } from '../index.js';
+import { GraphHttpResponseError } from '../error.js';
+
+describe('GraphQL Error Handling', () => {
+  describe('invalid API key', () => {
+    test('should throw GraphHttpResponseError with 401 status', async () => {
+      const client = new GraphClient('invalid-api-key', {
+        graphUrl: process.env.OPTIMIZELY_GRAPH_GATEWAY ||
+          'https://cg.optimizely.com/content/v2',
+      });
+
+      try {
+        await client.getContentByPath('/en/start/');
+        throw new Error('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphHttpResponseError);
+        if (error instanceof GraphHttpResponseError) {
+          expect(error.status).toBe(401);
+        }
+      }
+    });
+  });
+
+  describe('invalid URL', () => {
+    test('should handle invalid graph URL gracefully', async () => {
+      const client = new GraphClient(
+        process.env.OPTIMIZELY_GRAPH_SINGLE_KEY || 'test-key',
+        {
+          graphUrl: 'https://invalid-domain-xyz-12345.example.com/content/v2',
+        }
+      );
+
+      try {
+        await client.getContentByPath('/en/start/');
+        throw new Error('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect(error).not.toBeInstanceOf(GraphHttpResponseError);
+      }
+    });
+  });
+});

--- a/packages/optimizely-cms-sdk/src/graph/__integration__/helpers.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__integration__/helpers.ts
@@ -1,0 +1,13 @@
+import { GraphClient } from '../index.js';
+
+export const createTestGraphClient = () => {
+  const apiKey = process.env.OPTIMIZELY_GRAPH_SINGLE_KEY!;
+  const graphUrl = process.env.OPTIMIZELY_GRAPH_GATEWAY;
+  return new GraphClient(apiKey, { graphUrl });
+};
+
+export const generateTestId = () =>
+  `TEST_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+
+export const waitForGraphIndexing = (ms = 5000) =>
+  new Promise(resolve => setTimeout(resolve, ms));

--- a/packages/optimizely-cms-sdk/src/graph/__integration__/setup.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__integration__/setup.ts
@@ -2,33 +2,30 @@ import { readFileSync, existsSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const envPath = resolve(__dirname, '../../../../../.env.integration');
+const envPath = resolve(__dirname, '../../../../.env.integration');
 
 if (existsSync(envPath)) {
-  try {
-    const envFile = readFileSync(envPath, 'utf-8');
-    envFile.split('\n').forEach(line => {
-      const trimmed = line.trim();
-      if (trimmed && !trimmed.startsWith('#')) {
-        const [key, ...valueParts] = trimmed.split('=');
-        const value = valueParts.join('=');
-        if (key && value) {
-          process.env[key.trim()] = value.trim();
-        }
+  const envFile = readFileSync(envPath, 'utf-8');
+  envFile.split('\n').forEach((line: any) => {
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=');
+      const value = valueParts.join('=');
+      if (key && value) {
+        process.env[key.trim()] = value.trim();
       }
-    });
-  } catch (err) {
-    console.warn('Failed to load .env.integration:', err);
-  }
+    }
+  });
 } else {
   console.error(
-    '\n❌ Missing .env.integration file\n' +
+    '❌ Missing .env.integration file\n' +
     '   GraphQL integration tests will be skipped.\n' +
-    '   To enable integration tests:\n' +
-    '   1. cp .env.integration.template .env.integration\n' +
-    '   2. Add your CMS credentials to .env.integration\n' +
-    '   See INTEGRATION_TESTS.md for details.\n'
+    '   See INTEGRATION_TESTS.md for setup instructions.\n'
   );
 }
 

--- a/packages/optimizely-cms-sdk/src/graph/__integration__/setup.ts
+++ b/packages/optimizely-cms-sdk/src/graph/__integration__/setup.ts
@@ -1,0 +1,40 @@
+import { readFileSync, existsSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(__dirname, '../../../../../.env.integration');
+
+if (existsSync(envPath)) {
+  try {
+    const envFile = readFileSync(envPath, 'utf-8');
+    envFile.split('\n').forEach(line => {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        const [key, ...valueParts] = trimmed.split('=');
+        const value = valueParts.join('=');
+        if (key && value) {
+          process.env[key.trim()] = value.trim();
+        }
+      }
+    });
+  } catch (err) {
+    console.warn('Failed to load .env.integration:', err);
+  }
+} else {
+  console.error(
+    '\n❌ Missing .env.integration file\n' +
+    '   GraphQL integration tests will be skipped.\n' +
+    '   To enable integration tests:\n' +
+    '   1. cp .env.integration.template .env.integration\n' +
+    '   2. Add your CMS credentials to .env.integration\n' +
+    '   See INTEGRATION_TESTS.md for details.\n'
+  );
+}
+
+if (!process.env.OPTIMIZELY_GRAPH_SINGLE_KEY) {
+  console.error(
+    '❌ Missing OPTIMIZELY_GRAPH_SINGLE_KEY in .env.integration\n' +
+    '   GraphQL integration tests will be skipped.\n'
+  );
+}

--- a/packages/optimizely-cms-sdk/tsconfig.base.json
+++ b/packages/optimizely-cms-sdk/tsconfig.base.json
@@ -11,5 +11,6 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__integration__/**"]
 }

--- a/packages/optimizely-cms-sdk/tsconfig.json
+++ b/packages/optimizely-cms-sdk/tsconfig.json
@@ -8,5 +8,5 @@
     "noEmit": true
   },
   "include": ["src/**/*"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "src/**/__integration__/**"]
 }

--- a/packages/optimizely-cms-sdk/vitest.config.ts
+++ b/packages/optimizely-cms-sdk/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    exclude: ['src/**/__integration__/**'],
+    exclude: ['node_modules/**', 'src/**/__integration__/**'],
   },
   esbuild: {
     jsx: 'automatic',

--- a/packages/optimizely-cms-sdk/vitest.config.ts
+++ b/packages/optimizely-cms-sdk/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    exclude: ['node_modules/**', 'src/**/__integration__/**'],
+    exclude: ['node_modules/**', 'dist/**', 'src/**/__integration__/**'],
   },
   esbuild: {
     jsx: 'automatic',

--- a/packages/optimizely-cms-sdk/vitest.integration.config.ts
+++ b/packages/optimizely-cms-sdk/vitest.integration.config.ts
@@ -3,16 +3,16 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'jsdom',
     globals: true,
-    exclude: ['src/**/__integration__/**'],
-  },
-  esbuild: {
-    jsx: 'automatic',
+    environment: 'node',
+    include: ['src/**/__integration__/**/*.integration.test.ts'],
+    setupFiles: ['src/graph/__integration__/setup.ts'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    retry: 1,
   },
   resolve: {
     alias: {
-      // Handle .js imports in TypeScript files
       '~/': new URL('./src/', import.meta.url).pathname,
     },
   },


### PR DESCRIPTION
Provides a basic setup for integration testing for both the sdk and the cli. Testing is setup to be manual against a cms instance of your choice (using the vars in .env.integration). There are separate configs which ensure that normal testing ignores integration tests. There is a short description of the state of integration testing in DEVELOPMENT.md