### PR TITLE
Bug: CMS-55972 Reset button missing type="reset"

### DIFF
--- a/packages/optimizely-cms-sdk/src/forms/buttonRole.ts
+++ b/packages/optimizely-cms-sdk/src/forms/buttonRole.ts
@@ -1,4 +1,4 @@
-export type FormButtonRole = 'next' | 'previous' | 'submit';
+export type FormButtonRole = 'next' | 'previous' | 'submit' | 'reset';
 
 /**
  * Optimizely Forms has no property marking a button as step navigation: Next,
@@ -20,6 +20,7 @@ export type FormButtonContent = {
 
 export type FormButtonLabelOptions = {
   labels?: { next?: string[]; previous?: string[] };
+  role?: FormButtonRole;
 };
 
 const matches = (label: string, candidates: string[]) =>
@@ -36,6 +37,8 @@ export function getFormButtonRole(
   content: FormButtonContent,
   options: FormButtonLabelOptions = {},
 ): FormButtonRole {
+  if (options.role) return options.role;
+
   const label = content.Label?.trim().toLowerCase() ?? '';
   const nextLabels = options.labels?.next ?? DEFAULT_STEP_BUTTON_LABELS.next;
   const previousLabels = options.labels?.previous ?? DEFAULT_STEP_BUTTON_LABELS.previous;

--- a/packages/optimizely-cms-sdk/src/react/__test__/useFormButton.test.tsx
+++ b/packages/optimizely-cms-sdk/src/react/__test__/useFormButton.test.tsx
@@ -8,12 +8,14 @@ function Button({
   id,
   label,
   labels,
+  roleOverride,
 }: {
   id: string;
   label: string;
   labels?: { next?: string[]; previous?: string[] };
+  roleOverride?: 'next' | 'previous' | 'submit' | 'reset';
 }) {
-  const { role, buttonProps } = useFormButton({ Label: label }, { labels });
+  const { role, buttonProps } = useFormButton({ Label: label }, { labels, role: roleOverride });
 
   return (
     <button {...buttonProps} data-testid={id} data-role={role}>
@@ -99,6 +101,15 @@ describe('useFormButton', () => {
 
     expect(roleOf('next')).toBe('next');
     expect(roleOf('prev')).toBe('previous');
+  });
+
+  test('a reset role override produces type=reset', () => {
+    renderButtons(
+      <Button id='reset' label='Reset' roleOverride='reset' />,
+    );
+
+    expect(roleOf('reset')).toBe('reset');
+    expect(typeOf('reset')).toBe('reset');
   });
 
   test('an unrecognised label stays a submit button', () => {

--- a/packages/optimizely-cms-sdk/src/react/forms/FormWrapper.tsx
+++ b/packages/optimizely-cms-sdk/src/react/forms/FormWrapper.tsx
@@ -205,7 +205,12 @@ function FormWrapperContent({
   return (
     <FormRulesProvider rules={Array.isArray(rules) ? rules : undefined}>
       <FormStepsContext.Provider value={{ currentStepIndex, nextStep, prevStep }}>
-        <form ref={formRef} onSubmit={handleSubmit}>
+        <form ref={formRef} onSubmit={handleSubmit} onReset={(e) => {
+          e.preventDefault();
+          resetFields();
+          setAttemptedSubmit(false);
+          setCurrentStepIndex(0);
+        }}>
           {children}
         </form>
       </FormStepsContext.Provider>

--- a/packages/optimizely-cms-sdk/src/react/forms/useFormButton.ts
+++ b/packages/optimizely-cms-sdk/src/react/forms/useFormButton.ts
@@ -34,7 +34,10 @@ export function useFormButton(
     isSubmitting,
     label: content.Label ?? 'Submit',
     buttonProps: {
-      type: role === 'submit' ? ('submit' as const) : ('button' as const),
+      type:
+        role === 'submit' ? ('submit' as const)
+        : role === 'reset' ? ('reset' as const)
+        : ('button' as const),
       // Disabled only while the request is in flight, to stop a double submit.
       // Disabling on validation errors hides the reason the form won't send;
       // submitting reports the errors and moves focus to the first bad field.

--- a/templates/stride/components/forms/FormReset.tsx
+++ b/templates/stride/components/forms/FormReset.tsx
@@ -10,7 +10,7 @@ type FormResetProps = {
 };
 
 export default function FormReset({ content }: FormResetProps) {
-  const { role, label, buttonProps } = useFormButton(content);
+  const { role, label, buttonProps } = useFormButton(content, { role: 'reset' });
   const { pa } = getPreviewUtils(content);
 
   return (

--- a/templates/stride/components/forms/formStyles.ts
+++ b/templates/stride/components/forms/formStyles.ts
@@ -30,4 +30,5 @@ export const buttonRoleClass = {
   submit: 'border-2 border-key1 bg-key1 text-foreground-inverted focus:ring-key1',
   next: 'border-2 border-key1 bg-key1 text-foreground-inverted focus:ring-key1',
   previous: 'border-2 border-foreground text-foreground focus:ring-foreground/30',
+  reset: 'border-2 border-foreground text-foreground focus:ring-foreground/30',
 };


### PR DESCRIPTION
Add 'reset' role to FormButtonRole so the reset button gets type="reset" instead of defaulting to type="submit". Wire up an onReset handler on the form to clear React controlled state via resetFields().

Bug: CMD-55972